### PR TITLE
[FE] 플립된 카드 이미지 화질 깨지는 이슈 개선

### DIFF
--- a/frontend/src/components/card/CardItem.tsx
+++ b/frontend/src/components/card/CardItem.tsx
@@ -122,24 +122,31 @@ export default function CardItem({
 
         {/* 카드 앞면 */}
         <div
-          className="absolute inset-0"
+          className="absolute inset-0 overflow-hidden rounded-lg"
           style={{
             backfaceVisibility: 'hidden',
-            transform: 'rotateY(180deg)', // 미리 뒤집어두기
+            transform: 'rotateY(180deg)',
           }}
         >
-          <div className="flex h-full w-full items-center justify-center overflow-hidden rounded-lg border-4 border-white bg-gray-100">
-            <Image
-              src={sampleImg}
-              alt="sample"
-              className="rounded-md object-cover"
-              draggable={false}
-              priority
+          {/* 회전 전용 wrapper - 부모의 w, h를 채우도록 */}
+          <div className="relative flex h-full w-full items-center justify-center">
+            <div
+              className="absolute"
               style={{
+                width: '240px', // CardItem의 h-60
+                height: '140px', // CardItem의 w-35
                 transform: 'rotate(90deg)',
-                scale: 1.5, // 추후 스케일로 지정하지 않게 고려필요
               }}
-            />
+            >
+              <Image
+                src={sampleImg}
+                alt="sample"
+                fill
+                className="rounded-lg border-4 border-white bg-gray-100 object-cover"
+                draggable={false}
+                priority
+              />
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 🎯 이슈 번호
bugfix로 이슈 번호 없음

---

## ✅ 작업 내용
- 회전 전용 wrapper 추가
- absolute-fill을 적용함으로써 레이아웃 조정

기존에 카드 이미지를 scale-up으로 처리함으로써 생겼던 화질 깨지는 이슈를 해결하였습니다.

---

## 🤔 리뷰 요구사항

고정된 카드 해상도를 이용해 레이아웃을 조정해 scale 속성을 쓰지 않도록 했습니다. 혹시나 더 바람직한 방법이 있다면 자유롭게 피드백주세요.

---

## 📸 스크린샷 (선택)
https://github.com/user-attachments/assets/d071e45e-3268-42fe-94a5-c42ed7f90a02


<img width="1461" height="710" alt="스크린샷 2025-12-30 17 26 39" src="https://github.com/user-attachments/assets/691e5796-6a35-43d4-b5d4-df29741180d0" />

