### PR TITLE
[FE] whiteboard sidebar 디자인 수정

### DIFF
--- a/frontend/src/components/whiteboard/sidebar/Sidebar.tsx
+++ b/frontend/src/components/whiteboard/sidebar/Sidebar.tsx
@@ -179,16 +179,19 @@ export default function Sidebar() {
   };
 
   return (
-    <aside className="absolute top-1/2 left-2 z-5 flex max-h-[calc(100vh-2rem)] w-56 -translate-y-1/2 flex-col overflow-y-auto rounded-lg border border-neutral-200 bg-white p-4 shadow-xl">
+    <aside
+      className="absolute top-1/2 left-2 z-5 flex w-60 -translate-y-1/2 flex-col overflow-hidden rounded-lg border border-neutral-200 bg-white p-4 shadow-xl"
+      style={{ maxHeight: 'calc(100vh - 220px)' }}
+    >
       {/* Sidebar Title */}
-      <div className="mb-1">
+      <div className="mb-2 shrink-0 border-b border-neutral-100 pb-2">
         <h2 className="text-lg font-bold text-neutral-800">
           {getHeaderTitle()}
         </h2>
       </div>
 
       {/* 패널 영역 */}
-      <div className="flex-1">
+      <div className="min-h-0 flex-1 overflow-y-auto px-1 pr-2">
         {/* shape */}
         {selectionType === 'shape' && (
           <ShapePanel
@@ -395,6 +398,7 @@ export default function Sidebar() {
             onChangeLayer={handleLayerChange}
           />
         )}
+
         {/* drawing */}
         {(cursorMode === 'draw' || selectionType === 'drawing') && (
           <DrawingPanel
@@ -426,6 +430,7 @@ export default function Sidebar() {
             onChangeLayer={selectedItem ? handleLayerChange : undefined}
           />
         )}
+
         {/* stack */}
         {selectionType === 'stack' && (
           <StackPanel

--- a/frontend/src/components/whiteboard/sidebar/ui/Section.tsx
+++ b/frontend/src/components/whiteboard/sidebar/ui/Section.tsx
@@ -10,7 +10,7 @@ interface SectionProps {
 
 export default function Section({ title, children }: SectionProps) {
   return (
-    <div className="flex flex-col gap-2 py-2">
+    <div className="flex flex-col gap-2 px-1 py-2">
       {title && (
         <h3 className="text-xs font-bold tracking-wide text-black uppercase select-none">
           {title}


### PR DESCRIPTION
## ✅ 작업 내용
- 화이트 보드 쪽 sidebar의 위치와 크기만 수정되었습니다.

---

## 📸 스크린샷 (선택)

<img width="1919" height="741" alt="스크린샷 2026-01-28 오전 1 53 46" src="https://github.com/user-attachments/assets/ed197512-2e95-4a50-b269-48f98a13154b" />

<img width="1175" height="477" alt="스크린샷 2026-01-28 오전 1 54 11" src="https://github.com/user-attachments/assets/0711daf9-2fe5-4d4f-8546-52b4f9995641" />

