### PR TITLE
[FE] 화이트보드 업데이트 시 낙관적 업데이트 적용

### DIFF
--- a/frontend/src/hooks/useItemActions.ts
+++ b/frontend/src/hooks/useItemActions.ts
@@ -237,11 +237,15 @@ export function useItemActions() {
     const yMap = yMaps[index];
 
     // 로컬 store 먼저 업데이트
-    const currentItems = useWhiteboardSharedStore.getState().items;
-    const optimisticItems = currentItems.map((item) =>
-      item.id === id ? { ...item, ...changes } : item,
-    ) as WhiteboardItem[];
-    useWhiteboardSharedStore.getState().setItems(optimisticItems);
+    const store = useWhiteboardSharedStore.getState();
+    const currentItems = store.items;
+    const targetItem = currentItems[index];
+
+    if (targetItem) {
+      const optimisticItems = [...currentItems];
+      optimisticItems[index] = { ...targetItem, ...changes } as WhiteboardItem;
+      store.setItems(optimisticItems);
+    }
 
     // Yjs 업데이트
     yItems.doc.transact(() => {


### PR DESCRIPTION
🎯 이슈 번호

---

## ✅ 작업 내용
- 화이트보드 업데이트 시 낙관적 업데이트 적용

---

## 🤔 리뷰 요구사항
- 기존에는 Yjs 문서만 업데이트한 후 observeDeep을 통해 로컬 store에 반영하는 방식이었으나, 동기화 지연으로 인해 드래그/Transform 종료 시 깜빡임이 발생하여. 로컬 store를 먼저 업데이트하고 이후 Yjs 문서를  동기화하도록 수정했습니다.


---

## 📸 스크린샷 (선택)
<!-- UI 변경 사항이 있다면 스크린샷을 첨부해주세요 -->

(적용전)

https://github.com/user-attachments/assets/39953f7d-e2d3-4366-9ded-7ce1936c9e82


(적용후)

https://github.com/user-attachments/assets/7aad14c5-26d8-4fbc-8a76-ea06beab8ddf


