### PR TITLE
코드에디터 실시간 동기화 로직 로깅

### DIFF
--- a/frontend/src/instrumentation-client.ts
+++ b/frontend/src/instrumentation-client.ts
@@ -17,6 +17,10 @@ Sentry.init({
   debug: !isProd,
   enabled: true,
 
+  _experiments: {
+    metrics: true,
+  },
+
   // Enable logs to be sent to Sentry
   enableLogs: true,
 

--- a/frontend/src/types/error.ts
+++ b/frontend/src/types/error.ts
@@ -1,0 +1,8 @@
+export const ErrorType = {
+  HTTP: 'http',
+  SOCKET: 'socket',
+  SYNC: 'sync',
+  MEDIA: 'media',
+  EDITOR: 'editor',
+  AUTH: 'auth',
+} as const;

--- a/frontend/src/utils/logging.ts
+++ b/frontend/src/utils/logging.ts
@@ -1,0 +1,65 @@
+import * as Sentry from '@sentry/nextjs';
+
+export function captureError(params: {
+  error: unknown;
+  type: string;
+  message: string;
+  tags?: Record<string, string>;
+  extra?: Record<string, unknown>;
+}) {
+  Sentry.withScope((scope) => {
+    scope.setTag('error_type', params.type);
+
+    if (params.tags) scope.setTags(params.tags);
+    if (params.extra) scope.setContext('details', params.extra);
+
+    // Fingerprint를 설정하면 Sentry에서 이슈를 그룹화하는 방식을 직접 제어 가능
+    scope.setFingerprint([params.type, params.message]);
+
+    const exception =
+      params.error instanceof Error ? params.error : new Error(params.message);
+    Sentry.captureException(exception);
+  });
+}
+
+export function socketBreadcrumb(
+  event: string,
+  data?: unknown,
+  level: 'info' | 'warning' | 'error' = 'info',
+) {
+  Sentry.addBreadcrumb({
+    category: 'socket',
+    message: event,
+    data: data ? { payload: data } : undefined,
+    level,
+  });
+}
+
+type Level = 'info' | 'warning' | 'error';
+
+export function syncLog(
+  name: string,
+  data: Record<string, any> = {},
+  level: Level = 'info',
+) {
+  // breadcrumb (타임라인)
+  Sentry.addBreadcrumb({
+    category: 'yjs-sync',
+    message: name,
+    level,
+    data,
+  });
+
+  // anomaly / simulation 은 event로도 쏘기
+  if (level !== 'info') {
+    Sentry.captureMessage(`[SYNC] ${name}`, {
+      level,
+      extra: data,
+    });
+  }
+
+  if (process.env.NODE_ENV === 'development') {
+    // eslint-disable-next-line no-console
+    console.log(`🧩 [${name}]`, data);
+  }
+}


### PR DESCRIPTION

## ✅ 작업 내용
- 토큰 없을 때, res.ok가 false일 때 에러 로깅 추가
- update → ACK → full-state 전송 흐름으로 Sentry Breadcrumb 커스텀
  - 동기화 흐름 모니터링 위해 섹션별 로깅
- ACK 수신 여부와 관계없이 로컬 업데이트를 큐에 담아 병합 전송하는 구조로 개선
```ts
const BUFFER_WINDOW_MS = 50; // 로컬 update를 모아서 한번에 전송하는 time window (50ms)
const MAX_PENDING_UPDATES = 10; // ack를 기다리는 동안 동시에 쌓아둘 수 있는 최대 update 개수
const MAX_MERGED_BYTES = 8 * 1024; // 8KB (한번에 병합해서 보낼 update 데이터의 최대 크기)
```


---

## 🤔 리뷰 요구사항

서버 응답을 기다리는 동안 (awaitingAck가 true일 때) 버려지는 로컬 업데이트 상태를 관리하기 위해 업데이트큐를 만들어 쌓는 구조로 개선하였습니다. 50ms 쓰로틀링을 두고 Y.mergeUpdates()로 묶어 전송되게 하였습니다.

구조 | awaitingAck 중 로컬 변경
-- | --
기존 | dirty 세팅 → ACK 후 full-state
변경 | 버퍼링 → merge → patch 전송 (overflow 시만 full-state)


### 기존 구조
```
로컬 update 발생
→ awaitingAck false면 update 전송
→ awaitingAck true면 dirty = true

ACK 수신
→ awaitingAck false로 변경
→ dirty가 true면 full-state 전송
```
=> ACK 기다리는 동안 온 변경은 버퍼링하지 않고 나중에 full-state로 덮어씌우는 방식

[문제점]
```
update → ACK 대기
update → dirty
update → dirty
update → dirty
ACK
→ full-state 전송
```
ACK latency가 높으면 거의 매번 full-state로 가게 됨

### 개선 구조
```
awaitingAck 중이면
→ pendingUpdates에 push
→ 50ms 버퍼링
→ merge
→ ACK 후 patch로 전송
→ overflow 시에만 full-state
```





