### PR TITLE
[FE] 채팅 로직 리팩토링

### DIFF
--- a/frontend/src/components/meeting/MeetingMenu.tsx
+++ b/frontend/src/components/meeting/MeetingMenu.tsx
@@ -24,9 +24,9 @@ import { useRouter } from 'next/navigation';
 import { useRef, useState } from 'react';
 import { useWhiteboardSocket } from '@/hooks/useWhiteboardSocket';
 import { useWindowSize } from '@/hooks/useWindowSize';
-import { useChatStore } from '@/store/useChatStore';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import { useMeetingSocketStore } from '@/store/useMeetingSocketStore';
+import { useResetMessages } from '@/store/useChatStore';
 
 export default function MeetingMenu() {
   const { width } = useWindowSize();
@@ -61,6 +61,8 @@ export default function MeetingMenu() {
 
   // 화이트보드 연결 / 해제 함수 가져오기
   const { openWhiteboard, closeWhiteboard } = useWhiteboardSocket();
+
+  const resetMessages = useResetMessages();
 
   const isSomeoneSharing = screenSharer !== null;
   const isDisabledSharing = isSomeoneSharing && !screenShareOn;
@@ -212,7 +214,7 @@ export default function MeetingMenu() {
     onConfirm: () => void;
   } | null>(null);
   const onExit = () => {
-    useChatStore.getState().reset();
+    resetMessages();
     window.location.href = '/';
   };
 

--- a/frontend/src/components/meeting/chat/ChatContainer.tsx
+++ b/frontend/src/components/meeting/chat/ChatContainer.tsx
@@ -1,12 +1,12 @@
 import { useChatScroll } from '@/hooks/chat/useChatScroll';
-import { useChatStore } from '@/store/useChatStore';
+import { useLastMessage, useMessageLength } from '@/store/useChatStore';
 import { useCallback, useLayoutEffect, useRef } from 'react';
 import ChatList from './ChatList';
 import { useUserStore } from '@/store/useUserStore';
 
 export default function ChatContainer() {
-  const messageLength = useChatStore((s) => s.messages.length);
-  const lastMessage = useChatStore((s) => s.messages[s.messages.length - 1]);
+  const messageLength = useMessageLength();
+  const lastMessage = useLastMessage();
   const userId = useUserStore((s) => s.userId);
 
   const { ref, isAtBottom, scrollToBottom, handleScroll } = useChatScroll();

--- a/frontend/src/components/meeting/chat/ChatContainer.tsx
+++ b/frontend/src/components/meeting/chat/ChatContainer.tsx
@@ -1,0 +1,61 @@
+import { useChatScroll } from '@/hooks/chat/useChatScroll';
+import { useChatStore } from '@/store/useChatStore';
+import { useLayoutEffect, useRef } from 'react';
+import ChatList from './ChatList';
+import { useUserStore } from '@/store/useUserStore';
+
+export default function ChatContainer() {
+  const messageLength = useChatStore((s) => s.messages.length);
+  const lastMessage = useChatStore((s) => s.messages[s.messages.length - 1]);
+  const userId = useUserStore((s) => s.userId);
+
+  const { ref, isAtBottom, scrollToBottom, handleScroll } = useChatScroll();
+
+  const prevLengthRef = useRef(0);
+
+  const shouldAutoScroll = isAtBottom || lastMessage?.userId === userId;
+
+  useLayoutEffect(() => {
+    if (messageLength === 0) return;
+
+    const isFirst = prevLengthRef.current === 0;
+
+    if (isFirst) {
+      scrollToBottom('auto');
+    } else {
+      if (shouldAutoScroll) {
+        scrollToBottom(lastMessage?.userId === userId ? 'auto' : 'smooth');
+      }
+    }
+
+    prevLengthRef.current = messageLength;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [messageLength, lastMessage, scrollToBottom, shouldAutoScroll]);
+
+  const hasNewMessage = messageLength > prevLengthRef.current;
+  const showScrollButton =
+    hasNewMessage && !isAtBottom && lastMessage?.userId !== userId;
+
+  const handleClick = () => {
+    scrollToBottom('smooth');
+  };
+
+  return (
+    <div
+      ref={ref}
+      onScroll={handleScroll}
+      className="chat-scrollbar flex-1 overflow-y-auto scroll-smooth"
+    >
+      <ChatList />
+
+      {showScrollButton && (
+        <button
+          onClick={handleClick}
+          className="absolute bottom-28 left-1/2 -translate-x-1/2 rounded-full bg-blue-600 px-4 py-2 text-xs text-white shadow-lg"
+        >
+          새 메시지 보기 ↓
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/meeting/chat/ChatList.tsx
+++ b/frontend/src/components/meeting/chat/ChatList.tsx
@@ -2,15 +2,15 @@ import { useChatStore } from '@/store/useChatStore';
 import { useUserStore } from '@/store/useUserStore';
 import { isSameMinute } from '@/utils/chat';
 import { ChatListItem } from './ChatListItem';
-import { useEffect, useRef } from 'react';
+import { memo, useEffect, useMemo, useRef } from 'react';
 import { useChatScroll } from '@/hooks/chat/useChatScroll';
 
 type Props = {
   scrollRef: React.RefObject<HTMLDivElement | null>;
 };
 
-export default function ChatList({ scrollRef }: Props) {
-  const { userId } = useUserStore();
+function ChatList({ scrollRef }: Props) {
+  const userId = useUserStore((s) => s.userId);
 
   const isFirstRender = useRef(true);
 
@@ -59,13 +59,9 @@ export default function ChatList({ scrollRef }: Props) {
   //   [isAtBottomRef, scrollToBottom],
   // );
 
-  return (
-    <section
-      ref={scrollRef}
-      onScroll={handleScroll}
-      className="chat-scrollbar flex-1 overflow-y-auto scroll-smooth pb-4"
-    >
-      {messages.map((chat, idx) => {
+  const chatItems = useMemo(
+    () =>
+      messages.map((chat, idx) => {
         const prevMsg = messages[idx - 1];
 
         const isDifferentUser = !prevMsg || prevMsg.userId !== chat.userId;
@@ -75,14 +71,19 @@ export default function ChatList({ scrollRef }: Props) {
         const showProfile = isDifferentUser || isDifferentTime;
 
         return (
-          <ChatListItem
-            key={chat.id}
-            {...chat}
-            showProfile={showProfile}
-            // onImageLoad={() => handleImageLoad(chat.userId === userId)}
-          />
+          <ChatListItem key={chat.id} {...chat} showProfile={showProfile} />
         );
-      })}
+      }),
+    [messages],
+  );
+
+  return (
+    <section
+      ref={scrollRef}
+      onScroll={handleScroll}
+      className="chat-scrollbar flex-1 overflow-y-auto scroll-smooth pb-4"
+    >
+      {chatItems}
 
       {showScrollBtn && (
         <button
@@ -98,3 +99,5 @@ export default function ChatList({ scrollRef }: Props) {
     </section>
   );
 }
+
+export default memo(ChatList);

--- a/frontend/src/components/meeting/chat/ChatList.tsx
+++ b/frontend/src/components/meeting/chat/ChatList.tsx
@@ -3,7 +3,11 @@ import { isSameMinute } from '@/utils/chat';
 import { ChatListItem } from './ChatListItem';
 import { memo, useMemo } from 'react';
 
-function ChatList() {
+type ChatListProps = {
+  onMediaLoad?: () => void;
+};
+
+function ChatList({ onMediaLoad }: ChatListProps) {
   const messages = useChatStore((s) => s.messages);
 
   const chatItems = useMemo(
@@ -18,10 +22,15 @@ function ChatList() {
         const showProfile = isDifferentUser || isDifferentTime;
 
         return (
-          <ChatListItem key={chat.id} {...chat} showProfile={showProfile} />
+          <ChatListItem
+            key={chat.id}
+            {...chat}
+            showProfile={showProfile}
+            onImageLoad={onMediaLoad ? () => onMediaLoad() : undefined}
+          />
         );
       }),
-    [messages],
+    [messages, onMediaLoad],
   );
 
   return <section className="pb-4">{chatItems}</section>;

--- a/frontend/src/components/meeting/chat/ChatList.tsx
+++ b/frontend/src/components/meeting/chat/ChatList.tsx
@@ -1,63 +1,10 @@
 import { useChatStore } from '@/store/useChatStore';
-import { useUserStore } from '@/store/useUserStore';
 import { isSameMinute } from '@/utils/chat';
 import { ChatListItem } from './ChatListItem';
-import { memo, useEffect, useMemo, useRef } from 'react';
-import { useChatScroll } from '@/hooks/chat/useChatScroll';
+import { memo, useMemo } from 'react';
 
-type Props = {
-  scrollRef: React.RefObject<HTMLDivElement | null>;
-};
-
-function ChatList({ scrollRef }: Props) {
-  const userId = useUserStore((s) => s.userId);
-
-  const isFirstRender = useRef(true);
-
+function ChatList() {
   const messages = useChatStore((s) => s.messages);
-  const { handleScroll, scrollToBottom, isAtBottom } = useChatScroll(scrollRef);
-
-  const lastMessage = messages[messages.length - 1];
-
-  // showScrollBtn을 렌더 시점에 계산
-  const showScrollBtn =
-    messages.length > 0 && !isAtBottom && lastMessage?.userId !== userId;
-
-  useEffect(() => {
-    if (!scrollRef.current || messages.length === 0) return;
-
-    if (isFirstRender.current) {
-      scrollToBottom();
-      isFirstRender.current = false;
-      return;
-    }
-
-    const lastMessage = messages[messages.length - 1];
-    const isMyMessage = lastMessage.userId === userId;
-
-    //    const isImageMessage =
-    //      lastMessage.content.type === 'file' &&
-    //      lastMessage.content.category === 'image';
-
-    //    // 이미지면 여기서 스크롤하지 않음
-    //    if (isImageMessage) return;
-
-    if (isMyMessage || isAtBottom) {
-      scrollToBottom(isMyMessage);
-      //   setShowScrollBtn(false);
-    } else {
-      //   setShowScrollBtn(true);
-    }
-  }, [messages, userId, scrollToBottom, isAtBottom]);
-
-  // const handleImageLoad = useCallback(
-  //   (isMine: boolean) => {
-  //     if (isAtBottomRef.current || isMine) {
-  //       scrollToBottom(true);
-  //     }
-  //   },
-  //   [isAtBottomRef, scrollToBottom],
-  // );
 
   const chatItems = useMemo(
     () =>
@@ -77,27 +24,7 @@ function ChatList({ scrollRef }: Props) {
     [messages],
   );
 
-  return (
-    <section
-      ref={scrollRef}
-      onScroll={handleScroll}
-      className="chat-scrollbar flex-1 overflow-y-auto scroll-smooth pb-4"
-    >
-      {chatItems}
-
-      {showScrollBtn && (
-        <button
-          onClick={() => {
-            scrollToBottom(true);
-            // setScrollBtn(false);
-          }}
-          className="absolute bottom-30 left-1/2 -translate-x-1/2 rounded-full bg-blue-600 px-4 py-2 text-xs text-white shadow-lg"
-        >
-          새 메시지 보기 ↓
-        </button>
-      )}
-    </section>
-  );
+  return <section className="pb-4">{chatItems}</section>;
 }
 
 export default memo(ChatList);

--- a/frontend/src/components/meeting/chat/ChatList.tsx
+++ b/frontend/src/components/meeting/chat/ChatList.tsx
@@ -1,4 +1,4 @@
-import { useChatStore } from '@/store/useChatStore';
+import { useMessages } from '@/store/useChatStore';
 import { isSameMinute } from '@/utils/chat';
 import { ChatListItem } from './ChatListItem';
 import { memo, useMemo } from 'react';
@@ -8,7 +8,7 @@ type ChatListProps = {
 };
 
 function ChatList({ onMediaLoad }: ChatListProps) {
-  const messages = useChatStore((s) => s.messages);
+  const messages = useMessages();
 
   const chatItems = useMemo(
     () =>

--- a/frontend/src/components/meeting/chat/ChatList.tsx
+++ b/frontend/src/components/meeting/chat/ChatList.tsx
@@ -1,0 +1,100 @@
+import { useChatStore } from '@/store/useChatStore';
+import { useUserStore } from '@/store/useUserStore';
+import { isSameMinute } from '@/utils/chat';
+import { ChatListItem } from './ChatListItem';
+import { useEffect, useRef } from 'react';
+import { useChatScroll } from '@/hooks/chat/useChatScroll';
+
+type Props = {
+  scrollRef: React.RefObject<HTMLDivElement | null>;
+};
+
+export default function ChatList({ scrollRef }: Props) {
+  const { userId } = useUserStore();
+
+  const isFirstRender = useRef(true);
+
+  const messages = useChatStore((s) => s.messages);
+  const { handleScroll, scrollToBottom, isAtBottom } = useChatScroll(scrollRef);
+
+  const lastMessage = messages[messages.length - 1];
+
+  // showScrollBtn을 렌더 시점에 계산
+  const showScrollBtn =
+    messages.length > 0 && !isAtBottom && lastMessage?.userId !== userId;
+
+  useEffect(() => {
+    if (!scrollRef.current || messages.length === 0) return;
+
+    if (isFirstRender.current) {
+      scrollToBottom();
+      isFirstRender.current = false;
+      return;
+    }
+
+    const lastMessage = messages[messages.length - 1];
+    const isMyMessage = lastMessage.userId === userId;
+
+    //    const isImageMessage =
+    //      lastMessage.content.type === 'file' &&
+    //      lastMessage.content.category === 'image';
+
+    //    // 이미지면 여기서 스크롤하지 않음
+    //    if (isImageMessage) return;
+
+    if (isMyMessage || isAtBottom) {
+      scrollToBottom(isMyMessage);
+      //   setShowScrollBtn(false);
+    } else {
+      //   setShowScrollBtn(true);
+    }
+  }, [messages, userId, scrollToBottom, isAtBottom]);
+
+  // const handleImageLoad = useCallback(
+  //   (isMine: boolean) => {
+  //     if (isAtBottomRef.current || isMine) {
+  //       scrollToBottom(true);
+  //     }
+  //   },
+  //   [isAtBottomRef, scrollToBottom],
+  // );
+
+  return (
+    <section
+      ref={scrollRef}
+      onScroll={handleScroll}
+      className="chat-scrollbar flex-1 overflow-y-auto scroll-smooth pb-4"
+    >
+      {messages.map((chat, idx) => {
+        const prevMsg = messages[idx - 1];
+
+        const isDifferentUser = !prevMsg || prevMsg.userId !== chat.userId;
+        const isDifferentTime =
+          !prevMsg || !isSameMinute(chat.createdAt, prevMsg.createdAt);
+
+        const showProfile = isDifferentUser || isDifferentTime;
+
+        return (
+          <ChatListItem
+            key={chat.id}
+            {...chat}
+            showProfile={showProfile}
+            // onImageLoad={() => handleImageLoad(chat.userId === userId)}
+          />
+        );
+      })}
+
+      {showScrollBtn && (
+        <button
+          onClick={() => {
+            scrollToBottom(true);
+            // setScrollBtn(false);
+          }}
+          className="absolute bottom-30 left-1/2 -translate-x-1/2 rounded-full bg-blue-600 px-4 py-2 text-xs text-white shadow-lg"
+        >
+          새 메시지 보기 ↓
+        </button>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/meeting/chat/ChatModal.tsx
+++ b/frontend/src/components/meeting/chat/ChatModal.tsx
@@ -10,7 +10,7 @@ import { useUserStore } from '@/store/useUserStore';
 import { mapRecvPayloadToChatMessage } from '@/utils/chat';
 import { formatFileSize } from '@/utils/formatter';
 import Image from 'next/image';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ChatList from './ChatList';
 
 type PendingFile = {
@@ -22,20 +22,24 @@ type PendingFile = {
 
 const MAX_FILE_SIZE = 100 * 1024 * 1024; // 100MB
 
-export default function ChatModal() {
+function ChatModal() {
+  console.count('ChatModal render');
+
   const scrollRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const sizeErrorTimerRef = useRef<NodeJS.Timeout | null>(null);
   const pendingFilesRef = useRef<PendingFile[]>([]);
 
-  const { setIsOpen } = useMeetingStore();
+  const setIsOpen = useMeetingStore((s) => s.setIsOpen);
 
   const [hasValue, setHasValue] = useState(false);
   const [pendingFiles, setPendingFiles] = useState<PendingFile[]>([]);
   const [showSizeError, setShowSizeError] = useState(false);
 
-  const { userId, nickname, profilePath } = useUserStore();
+  const userId = useUserStore((s) => s.userId);
+  const nickname = useUserStore((s) => s.nickname);
+  const profilePath = useUserStore((s) => s.profilePath);
   const socket = useMeetingSocketStore((s) => s.socket);
 
   const { sendMessage: sendTextMessage } = useChatSender({
@@ -209,7 +213,10 @@ export default function ChatModal() {
     }
   };
 
-  const isUploading = Object.values(uploadingMap).some(Boolean);
+  const isUploading = useMemo(
+    () => Object.values(uploadingMap).some(Boolean),
+    [uploadingMap],
+  );
 
   return (
     <aside className="meeting-side-modal z-6">
@@ -362,3 +369,5 @@ export default function ChatModal() {
     </aside>
   );
 }
+
+export default memo(ChatModal);

--- a/frontend/src/hooks/chat/useChatForm.ts
+++ b/frontend/src/hooks/chat/useChatForm.ts
@@ -1,0 +1,152 @@
+import { useState, useRef, useCallback, useMemo } from 'react';
+import { useFileUpload } from '@/hooks/chat/useFileUpload';
+import { useChatSender } from '@/hooks/chat/useChatSender';
+import { useChatStore } from '@/store/useChatStore';
+import { mapRecvPayloadToChatMessage } from '@/utils/chat';
+import { Socket } from 'socket.io-client';
+
+type PendingFile = {
+  file: File;
+  id: string;
+  preview?: string;
+  mediaType: 'image' | 'video' | 'file';
+};
+
+const MAX_FILE_SIZE = 100 * 1024 * 1024; // 100MB
+
+export const useChatForm = (
+  socket: Socket | null,
+  userId: string,
+  nickname: string,
+  profilePath: string,
+) => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const sizeErrorTimerRef = useRef<NodeJS.Timeout | null>(null);
+
+  const [hasValue, setHasValue] = useState(false);
+  const [pendingFiles, setPendingFiles] = useState<PendingFile[]>([]);
+  const [showSizeError, setShowSizeError] = useState(false);
+
+  const { sendMessage: sendTextMessage } = useChatSender({
+    socket,
+    userId,
+    nickname,
+    profileImg: profilePath,
+  });
+  const { uploadFile, progressMap, uploadingMap } = useFileUpload(socket);
+
+  // 파일 추가/삭제 로직
+  const addFiles = useCallback((files: File[]) => {
+    if (files.length === 0) return;
+
+    const oversizedFiles = files.filter((f) => f.size > MAX_FILE_SIZE);
+    if (oversizedFiles.length > 0) {
+      setShowSizeError(true);
+      if (sizeErrorTimerRef.current) {
+        clearTimeout(sizeErrorTimerRef.current);
+      }
+      sizeErrorTimerRef.current = setTimeout(
+        () => setShowSizeError(false),
+        3000,
+      );
+    }
+
+    const validFiles = files.filter((f) => f.size <= MAX_FILE_SIZE);
+    if (validFiles.length === 0) return;
+
+    const newFiles = validFiles.map((file) => {
+      const isImage = file.type.startsWith('image/');
+      const isVideo = file.type.startsWith('video/');
+
+      let mediaType: PendingFile['mediaType'] = 'file';
+      if (isImage) mediaType = 'image';
+      else if (isVideo) mediaType = 'video';
+
+      return {
+        file,
+        mediaType,
+        id: crypto.randomUUID(),
+        // 미리보기 URL 생성
+        preview: isImage || isVideo ? URL.createObjectURL(file) : undefined,
+      };
+    });
+
+    setPendingFiles((prev) => [...prev, ...newFiles]);
+  }, []);
+
+  // 파일 삭제 및 메모리 해제용
+  const clearFilePreview = (file: PendingFile) => {
+    if (file.preview) {
+      URL.revokeObjectURL(file.preview);
+    }
+  };
+
+  const removeFile = (id: string) => {
+    setPendingFiles((prev) => {
+      const target = prev.find((f) => f.id === id);
+      if (target) clearFilePreview(target);
+      return prev.filter((f) => f.id !== id);
+    });
+  };
+
+  const handleSubmit = async (e?: React.FormEvent) => {
+    e?.preventDefault();
+
+    const textValue = textareaRef.current?.value.trim();
+    if (!textValue && pendingFiles.length === 0) return;
+
+    if (textValue) {
+      sendTextMessage(textValue);
+
+      if (textareaRef.current) {
+        textareaRef.current.value = '';
+        textareaRef.current.style.height = 'auto'; // 전송하고 높이 초기화
+        setHasValue(false);
+      }
+    }
+
+    if (pendingFiles.length > 0) {
+      const filesToUpload = [...pendingFiles];
+
+      await Promise.all(
+        filesToUpload.map(async (item) => {
+          try {
+            const res = await uploadFile(item.file, item.id);
+            if (res) {
+              // 서버 응답 데이터를 채팅 메시지 객체로 변환
+              const newMessage = mapRecvPayloadToChatMessage(res);
+              useChatStore.getState().addMessage(newMessage);
+
+              clearFilePreview(item); // 성공하면 메모리 해제
+
+              // 여기서 펜딩애들 제거
+              setPendingFiles((prev) => prev.filter((f) => f.id !== item.id));
+            }
+          } catch {
+            console.error(`${item.file.name} 업로드에 실패했습니다.`);
+          }
+        }),
+      );
+    }
+  };
+
+  const isUploading = useMemo(
+    () => Object.values(uploadingMap).some(Boolean),
+    [uploadingMap],
+  );
+
+  return {
+    textareaRef,
+    sizeErrorTimerRef,
+    pendingFiles,
+    hasValue,
+    showSizeError,
+    setHasValue,
+    addFiles,
+    removeFile,
+    handleSubmit,
+    uploadingMap,
+    progressMap,
+    isUploading,
+  };
+};

--- a/frontend/src/hooks/chat/useChatForm.ts
+++ b/frontend/src/hooks/chat/useChatForm.ts
@@ -1,9 +1,9 @@
 import { useState, useRef, useCallback, useMemo } from 'react';
 import { useFileUpload } from '@/hooks/chat/useFileUpload';
 import { useChatSender } from '@/hooks/chat/useChatSender';
-import { useChatStore } from '@/store/useChatStore';
 import { mapRecvPayloadToChatMessage } from '@/utils/chat';
 import { Socket } from 'socket.io-client';
+import { useAddMessage } from '@/store/useChatStore';
 
 type PendingFile = {
   file: File;
@@ -27,6 +27,7 @@ export const useChatForm = (
   const [pendingFiles, setPendingFiles] = useState<PendingFile[]>([]);
   const [showSizeError, setShowSizeError] = useState(false);
 
+  const addMessage = useAddMessage();
   const { sendMessage: sendTextMessage } = useChatSender({
     socket,
     userId,
@@ -115,8 +116,7 @@ export const useChatForm = (
             if (res) {
               // 서버 응답 데이터를 채팅 메시지 객체로 변환
               const newMessage = mapRecvPayloadToChatMessage(res);
-              useChatStore.getState().addMessage(newMessage);
-
+              addMessage(newMessage);
               clearFilePreview(item); // 성공하면 메모리 해제
 
               // 여기서 펜딩애들 제거

--- a/frontend/src/hooks/chat/useChatScroll.ts
+++ b/frontend/src/hooks/chat/useChatScroll.ts
@@ -1,35 +1,30 @@
-import { RefObject, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
-export const useChatScroll = (
-  containerRef: RefObject<HTMLDivElement | null>,
-) => {
+export const useChatScroll = () => {
   const [isAtBottom, setIsAtBottom] = useState(true);
+  const ref = useRef<HTMLDivElement>(null);
+
   const THRESHOLD = 150;
 
-  const checkIsNearBottom = () => {
-    const el = containerRef.current;
-    if (!el) return true;
-
-    return el.scrollHeight - el.scrollTop - el.clientHeight < THRESHOLD;
-  };
-
-  const handleScroll = () => {
-    const next = checkIsNearBottom();
-    setIsAtBottom((prev) => (prev === next ? prev : next));
-  };
-
-  const scrollToBottom = (isMyMessage = false) => {
-    const el = containerRef.current;
+  const scrollToBottom = useCallback((behavior: ScrollBehavior) => {
+    const el = ref.current;
     if (!el) return;
 
     el.scrollTo({
       top: el.scrollHeight,
-      behavior: isMyMessage ? 'auto' : 'smooth',
+      behavior,
     });
+  }, []);
 
-    // 메시지 전송 시 바로 아래로 이동했으므로 상태도 갱신
-    setIsAtBottom(true);
-  };
+  const handleScroll = useCallback(() => {
+    const el = ref.current;
+    if (!el) return;
 
-  return { handleScroll, scrollToBottom, isAtBottom };
+    const atBottom =
+      el.scrollHeight - el.scrollTop - el.clientHeight < THRESHOLD;
+
+    setIsAtBottom(atBottom);
+  }, []);
+
+  return { ref, isAtBottom, scrollToBottom, handleScroll };
 };

--- a/frontend/src/hooks/chat/useChatScroll.ts
+++ b/frontend/src/hooks/chat/useChatScroll.ts
@@ -1,9 +1,9 @@
-import { RefObject, useRef } from 'react';
+import { RefObject, useState } from 'react';
 
 export const useChatScroll = (
   containerRef: RefObject<HTMLDivElement | null>,
 ) => {
-  const isAtBottomRef = useRef(true);
+  const [isAtBottom, setIsAtBottom] = useState(true);
   const THRESHOLD = 150;
 
   const checkIsNearBottom = () => {
@@ -14,7 +14,8 @@ export const useChatScroll = (
   };
 
   const handleScroll = () => {
-    isAtBottomRef.current = checkIsNearBottom();
+    const next = checkIsNearBottom();
+    setIsAtBottom((prev) => (prev === next ? prev : next));
   };
 
   const scrollToBottom = (isMyMessage = false) => {
@@ -25,7 +26,10 @@ export const useChatScroll = (
       top: el.scrollHeight,
       behavior: isMyMessage ? 'auto' : 'smooth',
     });
+
+    // 메시지 전송 시 바로 아래로 이동했으므로 상태도 갱신
+    setIsAtBottom(true);
   };
 
-  return { handleScroll, scrollToBottom, isAtBottomRef };
+  return { handleScroll, scrollToBottom, isAtBottom };
 };

--- a/frontend/src/hooks/chat/useChatSocket.ts
+++ b/frontend/src/hooks/chat/useChatSocket.ts
@@ -1,8 +1,8 @@
 import { useEffect } from 'react';
 import { Socket } from 'socket.io-client';
-import { useChatStore } from '@/store/useChatStore';
 import { mapRecvPayloadToChatMessage } from '@/utils/chat';
 import { FileCategory } from '@/types/chat';
+import { useAddMessage } from '@/store/useChatStore';
 
 type BaseUserPayload = {
   user_id: string;
@@ -29,7 +29,7 @@ export type RecvMessagePayload =
   | (FileMessagePayload & BaseUserPayload);
 
 export const useChatSocket = (socket: Socket | null) => {
-  const addMessage = useChatStore((s) => s.addMessage);
+  const addMessage = useAddMessage();
 
   useEffect(() => {
     if (!socket) return;

--- a/frontend/src/hooks/chat/useFileUpload.ts
+++ b/frontend/src/hooks/chat/useFileUpload.ts
@@ -146,10 +146,17 @@ export const useFileUpload = (socket: Socket | null) => {
         console.error('upload error:', err);
         throw err;
       } finally {
-        setUploadingMap((m) => ({
-          ...m,
-          [pendingId]: false,
-        }));
+        setUploadingMap((m) => {
+          const next = { ...m };
+          delete next[pendingId];
+          return next;
+        });
+
+        setProgressMap((m) => {
+          const next = { ...m };
+          delete next[pendingId];
+          return next;
+        });
       }
     },
     [fileCheck, requestUploadTicket, socket],

--- a/frontend/src/store/useChatStore.ts
+++ b/frontend/src/store/useChatStore.ts
@@ -1,28 +1,57 @@
 import { ChatMessage } from '@/types/chat';
 import { create } from 'zustand';
+import { immer } from 'zustand/middleware/immer';
+import { combine } from 'zustand/middleware';
 import { useMeetingStore } from './useMeetingStore';
 
-interface ChatState {
-  messages: ChatMessage[];
-}
-
-interface ChatAction {
-  addMessage: (msg: ChatMessage) => void;
-  reset: () => void;
-}
-
-export const useChatStore = create<ChatState & ChatAction>((set) => ({
+const initialState: { messages: ChatMessage[] } = {
   messages: [],
+};
 
-  addMessage: (msg) => {
-    set((state) => ({
-      messages: [...state.messages, msg],
-    }));
+const useChatStore = create(
+  immer(
+    combine(initialState, (set) => ({
+      actions: {
+        addMessage: (msg: ChatMessage) => {
+          set((state) => {
+            state.messages.push(msg);
+          });
 
-    const { isChatOpen, setHasNewChat } = useMeetingStore.getState();
-    if (!isChatOpen) {
-      setHasNewChat(true);
-    }
-  },
-  reset: () => set({ messages: [] }),
-}));
+          const { isChatOpen, setHasNewChat } = useMeetingStore.getState();
+          if (!isChatOpen) setHasNewChat(true);
+        },
+        reset: () =>
+          set((state) => {
+            state.messages = [];
+          }),
+      },
+    })),
+  ),
+);
+
+export const useMessages = () => {
+  const messages = useChatStore((store) => store.messages);
+  return messages;
+};
+
+export const useAddMessage = () => {
+  const addMessage = useChatStore((store) => store.actions.addMessage);
+  return addMessage;
+};
+
+export const useResetMessages = () => {
+  const resetMessages = useChatStore((store) => store.actions.reset);
+  return resetMessages;
+};
+
+export const useMessageLength = () => {
+  const messageLenth = useChatStore((store) => store.messages.length);
+  return messageLenth;
+};
+
+export const useLastMessage = () => {
+  const lastMessage = useChatStore(
+    (store) => store.messages[store.messages.length - 1],
+  );
+  return lastMessage;
+};

--- a/frontend/src/store/useChatStore.ts
+++ b/frontend/src/store/useChatStore.ts
@@ -45,8 +45,8 @@ export const useResetMessages = () => {
 };
 
 export const useMessageLength = () => {
-  const messageLenth = useChatStore((store) => store.messages.length);
-  return messageLenth;
+  const messageLength = useChatStore((store) => store.messages.length);
+  return messageLength;
 };
 
 export const useLastMessage = () => {


### PR DESCRIPTION


## ✅ 작업 내용
- 채팅 스토어 구조 리팩토링 및 타입 최적화
   - immer와 combine 미들웨어를 도입하여 불변성 관리 로직 단순화 및 타입 추론 자동화
   - 상태(State)와 액션(Actions)을 분리하여 스토어 구조 개선
   - useMessages, useAddMessage 등 전용 셀렉터 훅을 구현하여 컴포넌트 내 불필요한 리렌더링 방지

- 채팅 컴포넌트 책임 분리 및 구조 개선
   - ChatContainer, ChatList, ChatListItem으로 컴포넌트를 세분화하여 각 컴포넌트의 역할 명확히 정의
   - 채팅 폼의 비즈니스 로직을 useChatForm 커스텀 훅으로 추출하여 UI와 로직 분리

- 성능 최적화 및 안정성 보완
   - 채팅 리스트 및 주요 메서드에 메모이제이션(useMemo, useCallback)을 적용하여 불필요한 연산 방지
   - 이미지 메시지 로드(onLoad) 처리 및 업로드 상태 맵 정리 로직 개선
   - 이중 서브밋 방지 및 타이머/Preview URL 등 메모리 누수 방지를 위한 Cleanup 로직 보완

- UX 개선 
    - 채팅 스크롤 커스텀 훅의 내부 로직을 수정하여 메시지 수신 시 스크롤 동작 최적화
---

## 🤔 리뷰 요구사항

- Zustand 미들웨어를 학습한 후 immer와 combine을 활용해 스토어 구조를 리팩토링했습니다. 해당 구조가 확장성 측면에서 괜찮은지 피드백주시면 좋을 것 같습니다.
- 컴포넌트 분리: ChatContainer에서 ChatList와 ChatForm으로 책임을 분리했는데, Props 전달 구조가 너무 복잡하지는 않은지 피드백주시면 감사하겠습니다.

