### PR TITLE
[FE] 영상이나 마이크를 켠 상태로 진입하는 참가자 정보가 제대로 반영되지 않는 문제 해결

### DIFF
--- a/frontend/src/components/__tests__/meeting/MemberVideoBar.test.tsx
+++ b/frontend/src/components/__tests__/meeting/MemberVideoBar.test.tsx
@@ -2,9 +2,12 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { useMeetingStore } from '@/store/useMeetingStore';
 import { useMeetingSocketStore } from '@/store/useMeetingSocketStore';
 import { MeetingMemberInfo } from '@/types/meeting';
-import { getMembersPerPage } from '@/utils/meeting';
+import { getMembersPerPage, getVideoConsumerIds } from '@/utils/meeting';
+import { MemberProviderInfo } from '@/types/meeting';
 import { useWindowSize } from '@/hooks/useWindowSize';
 import MemberVideoBar from '@/components/meeting/MemberVideoBar';
+import { Socket } from 'socket.io-client';
+import { Device, Transport } from 'mediasoup-client/types';
 
 jest.mock('@/utils/meeting', () => ({
   getMembersPerPage: jest.fn(),
@@ -70,27 +73,66 @@ describe('<MemberVideoBar />', () => {
   });
 
   it('1페이지(6슬롯)에서는 MyVideo가 보이고, 나머지 5칸에 멤버들이 표시된다', () => {
+    const mockSocket = {
+      emitWithAck: jest.fn().mockResolvedValue({ consumerInfos: [] }),
+      emit: jest.fn(),
+      on: jest.fn(),
+      off: jest.fn(),
+    } as unknown as Socket;
+
+    const mockTransport = {
+      id: 'test-transport',
+    } as unknown as Transport;
+
+    const mockDevice = {
+      rtpCapabilities: {},
+    } as unknown as Device;
+
+    useMeetingSocketStore.setState({
+      socket: mockSocket,
+      recvTransport: mockTransport,
+      device: mockDevice,
+      consumers: {},
+      addConsumers: jest.fn(),
+    });
+
     // Given: 멤버 10명
     const members: Record<string, MeetingMemberInfo> = {};
     const orderedIds: string[] = [];
+    const producers: Record<
+      string,
+      { cam?: MemberProviderInfo | null; mic?: MemberProviderInfo | null }
+    > = {};
+
     for (let i = 1; i <= 10; i++) {
       const m = createMember(i);
       members[m.user_id] = m;
       orderedIds.push(m.user_id);
+      // also add dummy producer info to ensure it gets passed
+      producers[m.user_id] = { cam: null, mic: null };
     }
-    useMeetingStore.setState({ members, orderedMemberIds: orderedIds });
+
+    useMeetingStore.setState({
+      members,
+      orderedMemberIds: orderedIds,
+      memberProducers: producers,
+    });
 
     render(<MemberVideoBar />);
 
-    // Then
+    // Then layout should still be correct
     expect(screen.getByTestId('my-video')).toBeInTheDocument();
-
-    // 1페이지 멤버: 총 6슬롯 - MyVideo(1) = 5명
     const memberVideos = screen.getAllByTestId('member-video');
     expect(memberVideos).toHaveLength(5);
-
     expect(memberVideos[0]).toHaveTextContent('Member 1');
     expect(memberVideos[4]).toHaveTextContent('Member 5');
+
+    // getVideoConsumerIds should be called with producers map
+    expect(
+      (getVideoConsumerIds as jest.Mock).mock.calls.length,
+    ).toBeGreaterThan(0);
+    const firstArg = (getVideoConsumerIds as jest.Mock).mock.calls[0][0];
+    expect(firstArg).toBe(producers);
   });
 
   it('다음 버튼을 누르면 2페이지로 이동하고 MyVideo 없이 6명의 멤버가 표시된다', () => {

--- a/frontend/src/components/meeting/GlobalAudioPlayer.tsx
+++ b/frontend/src/components/meeting/GlobalAudioPlayer.tsx
@@ -8,8 +8,12 @@ import { getAudioConsumerIds, getConsumerInstances } from '@/utils/meeting';
 import { useEffect, useRef } from 'react';
 
 export const GlobalAudioPlayer = () => {
-  const { members, memberStreams, setMemberStream, removeMemberStream } =
-    useMeetingStore();
+  const {
+    memberProducers,
+    memberStreams,
+    setMemberStream,
+    removeMemberStream,
+  } = useMeetingStore();
   const { socket, recvTransport, device, addConsumers } =
     useMeetingSocketStore();
 
@@ -25,7 +29,7 @@ export const GlobalAudioPlayer = () => {
 
       const currentConsumers = useMeetingSocketStore.getState().consumers;
       const { newAudioConsumers } = getAudioConsumerIds(
-        members,
+        memberProducers,
         currentConsumers,
       );
 
@@ -59,18 +63,16 @@ export const GlobalAudioPlayer = () => {
         addConsumers(newInstances);
 
         newInstances.forEach(({ producerId, consumer }) => {
-          const member = Object.values(members).find(
-            (m) => m.mic?.provider_id === producerId,
+          const entry = Object.entries(memberProducers).find(
+            ([, prod]) => prod.mic?.provider_id === producerId,
           );
-          if (member) {
-            if (!member.mic?.is_paused) {
-              setMemberStream(
-                member.user_id,
-                'mic',
-                new MediaStream([consumer.track]),
-              );
+          const userId = entry ? entry[0] : undefined;
+          if (userId) {
+            const isPaused = memberProducers[userId]?.mic?.is_paused;
+            if (!isPaused) {
+              setMemberStream(userId, 'mic', new MediaStream([consumer.track]));
             } else {
-              removeMemberStream(member.user_id, 'mic');
+              removeMemberStream(userId, 'mic');
             }
           }
         });
@@ -96,7 +98,7 @@ export const GlobalAudioPlayer = () => {
     return () => {
       isCancelled = true;
     };
-  }, [members, socket, recvTransport, device]);
+  }, [memberProducers, socket, recvTransport, device]);
 
   return (
     <div id="remote-audio-container" style={{ display: 'none' }}>

--- a/frontend/src/components/meeting/MeetingRoom.tsx
+++ b/frontend/src/components/meeting/MeetingRoom.tsx
@@ -51,6 +51,7 @@ export default function MeetingRoom() {
     removeMemberStream,
     setIsOpen,
     setScreenSharer,
+    setMemberProducer,
   } = useMeetingStore();
   const { userId } = useUserStore();
 
@@ -262,7 +263,16 @@ export default function MeetingRoom() {
         nickname: producerNickname,
         is_paused: isPaused,
         producer_id: producerId,
+        kind,
       } = producerInfo;
+
+      // memberProducer 정보 업데이트
+      setMemberProducer(userId, producerType as 'cam' | 'mic', {
+        provider_id: producerId,
+        kind,
+        type: producerType as 'cam' | 'mic',
+        is_paused: isPaused,
+      });
 
       const existingConsumer =
         useMeetingSocketStore.getState().consumers[producerId];

--- a/frontend/src/components/meeting/MemberVideoBar.tsx
+++ b/frontend/src/components/meeting/MemberVideoBar.tsx
@@ -24,12 +24,14 @@ export default function MemberVideoBar() {
 
   const {
     members,
+    memberProducers,
     setMemberStream,
     removeMemberStream,
     orderedMemberIds,
     pinnedMemberIds,
     lastSpeakerId,
     moveToFront,
+    setMemberProducer,
   } = useMeetingStore();
 
   const { socket, recvTransport, device, addConsumers } =
@@ -111,7 +113,11 @@ export default function MemberVideoBar() {
         pauseConsumerIds,
         visibleStreamTracks,
         hiddenUserIds,
-      } = getVideoConsumerIds(members, targetStreamMembers, currentConsumers);
+      } = getVideoConsumerIds(
+        memberProducers,
+        targetStreamMembers,
+        currentConsumers,
+      );
 
       const allResumeIds = [...resumeConsumerIds];
 
@@ -138,11 +144,13 @@ export default function MemberVideoBar() {
         newConsumers.forEach(({ producerId, consumer }) => {
           allResumeIds.push(consumer.id);
 
-          const userId = Object.values(members).find(
-            (m) => m.cam?.provider_id === producerId,
-          )?.user_id;
+          const userEntry = Object.entries(memberProducers).find(
+            ([, prod]) => prod.cam?.provider_id === producerId,
+          );
+          const userId = userEntry ? userEntry[0] : undefined;
           if (userId) {
-            if (members[userId].cam?.is_paused) {
+            const isPaused = memberProducers[userId]?.cam?.is_paused;
+            if (isPaused) {
               removeMemberStream(userId, 'cam');
             } else {
               setMemberStream(userId, 'cam', new MediaStream([consumer.track]));
@@ -157,13 +165,15 @@ export default function MemberVideoBar() {
 
         allResumeIds.forEach((consumerId) => {
           const consumer = currentConsumers[consumerId];
-          const userId = Object.values(members).find(
-            (m) => m.cam?.provider_id === consumerId,
-          )?.user_id;
+          const userEntry = Object.entries(memberProducers).find(
+            ([, prod]) => prod.cam?.provider_id === consumerId,
+          );
+          const userId = userEntry ? userEntry[0] : undefined;
 
           if (consumer && userId) {
             // 생산자가 진짜로 pause한 상태라면 연결하지 않음
-            if (members[userId].cam?.is_paused) {
+            const isPaused = memberProducers[userId]?.cam?.is_paused;
+            if (isPaused) {
               removeMemberStream(userId, 'cam');
             } else {
               setMemberStream(userId, 'cam', new MediaStream([consumer.track]));
@@ -173,7 +183,8 @@ export default function MemberVideoBar() {
 
         // 이미 활성화되어 있던 트랙들도 확실하게 다시 세팅
         visibleStreamTracks.forEach(({ userId, track }) => {
-          if (members[userId].cam?.is_paused) removeMemberStream(userId, 'cam');
+          const isPaused = memberProducers[userId]?.cam?.is_paused;
+          if (isPaused) removeMemberStream(userId, 'cam');
           else setMemberStream(userId, 'cam', new MediaStream([track]));
         });
       }
@@ -191,7 +202,7 @@ export default function MemberVideoBar() {
     socket,
     recvTransport,
     device,
-    members,
+    memberProducers,
     setMemberStream,
     removeMemberStream,
     addConsumers,
@@ -223,6 +234,13 @@ export default function MemberVideoBar() {
     const onCameraProduced = async (producerInfo: ProducerInfo) => {
       const { user_id: userId, producer_id: producerId, type } = producerInfo;
 
+      setMemberProducer(userId, type as 'cam' | 'mic', {
+        provider_id: producerId,
+        kind: producerInfo.kind,
+        type: producerInfo.type as 'cam' | 'mic',
+        is_paused: producerInfo.is_paused ?? false,
+      });
+
       // 기존 컨슈머가 있는지 확인 (Resume 처리)
       const consumers = useMeetingSocketStore.getState().consumers;
       const existingConsumer = consumers[producerId];
@@ -251,6 +269,17 @@ export default function MemberVideoBar() {
     };
 
     const onAlertProduced = (producerInfo: ProducerInfo) => {
+      setMemberProducer(
+        producerInfo.user_id,
+        producerInfo.type as 'cam' | 'mic',
+        {
+          provider_id: producerInfo.producer_id,
+          kind: producerInfo.kind,
+          type: producerInfo.type as 'cam' | 'mic',
+          is_paused: producerInfo.is_paused,
+        },
+      );
+
       if (producerInfo.type === 'cam' && producerInfo.is_restart) {
         checkAndMoveToFront(producerInfo.user_id);
       }

--- a/frontend/src/store/__tests__/useMeetingStore.test.ts
+++ b/frontend/src/store/__tests__/useMeetingStore.test.ts
@@ -153,12 +153,92 @@ describe('useMeetingStore', () => {
 
     act(() => {
       addMember(createMember());
-      setSpeaking('user1', true);
+      setSpeaking('user1', true, 6);
     });
 
     const state = useMeetingStore.getState();
 
     expect(state.speakingMembers['user1']).toBe(true);
     expect(state.lastSpeakerId).toBe('user1');
+  });
+
+  describe('producer metadata (memberProducers)', () => {
+    it('setMembers 초기화 시 cam/mic 필드가 복사된다', () => {
+      const { setMembers } = useMeetingStore.getState();
+      const member: MeetingMemberInfo = createMember({
+        cam: {
+          provider_id: 'cam-1',
+          kind: 'video',
+          type: 'cam',
+          is_paused: false,
+        },
+        mic: {
+          provider_id: 'mic-1',
+          kind: 'audio',
+          type: 'mic',
+          is_paused: true,
+        },
+      });
+
+      act(() => {
+        setMembers([member]);
+      });
+
+      const state = useMeetingStore.getState();
+      expect(state.memberProducers['user1']?.cam).toEqual(member.cam);
+      expect(state.memberProducers['user1']?.mic).toEqual(member.mic);
+    });
+
+    it('addMember는 새로운 엔트리를 생성하고 cam/mic을 채운다', () => {
+      const { addMember } = useMeetingStore.getState();
+      const member: MeetingMemberInfo = createMember({
+        user_id: 'user2',
+        cam: {
+          provider_id: 'cam-2',
+          kind: 'video',
+          type: 'cam',
+          is_paused: false,
+        },
+      });
+
+      act(() => {
+        addMember(member);
+      });
+
+      const state = useMeetingStore.getState();
+      expect(state.memberProducers['user2']?.cam).toEqual(member.cam);
+    });
+
+    it('setMemberProducer는 필드만 업데이트 한다', () => {
+      const { setMemberProducer, setMembers } = useMeetingStore.getState();
+      const member: MeetingMemberInfo = createMember({ user_id: 'user3' });
+
+      act(() => {
+        setMembers([member]);
+        setMemberProducer('user3', 'cam', {
+          provider_id: 'cam-x',
+          kind: 'video',
+          type: 'cam',
+          is_paused: true,
+        });
+      });
+
+      const state = useMeetingStore.getState();
+      expect(state.memberProducers['user3']?.cam?.provider_id).toBe('cam-x');
+      expect(state.memberProducers['user3']?.cam?.is_paused).toBe(true);
+    });
+
+    it('removeMember는 관련 producer 정보도 삭제한다', () => {
+      const { addMember, removeMember } = useMeetingStore.getState();
+      const member: MeetingMemberInfo = createMember({ user_id: 'user4' });
+
+      act(() => {
+        addMember(member);
+        removeMember('user4');
+      });
+
+      const state = useMeetingStore.getState();
+      expect(state.memberProducers['user4']).toBeUndefined();
+    });
   });
 });

--- a/frontend/src/store/useMeetingStore.ts
+++ b/frontend/src/store/useMeetingStore.ts
@@ -1,21 +1,24 @@
-import {
-  INITIAL_MEDIA_STATE,
-  INITIAL_MEETING_INFO,
-  VISIBLE_COUNT,
-} from '@/constants/meeting';
+import { INITIAL_MEDIA_STATE, INITIAL_MEETING_INFO } from '@/constants/meeting';
 import {
   MediaState,
   MediaType,
   MeetingInfo,
   MeetingMemberInfo,
   MemberStream,
+  MemberProviderInfo,
 } from '@/types/meeting';
-import { reorderMembers } from '@/utils/meeting';
 import { create } from 'zustand';
 
 interface MeetingState {
   media: MediaState;
   members: Record<string, MeetingMemberInfo>;
+  memberProducers: Record<
+    string,
+    {
+      cam?: MemberProviderInfo | null;
+      mic?: MemberProviderInfo | null;
+    }
+  >;
   memberStreams: Record<string, MemberStream>;
   hasNewChat: boolean;
   screenSharer: { id: string; nickname: string } | null;
@@ -39,6 +42,11 @@ interface MeetingActions {
   setMembers: (members: MeetingMemberInfo[]) => void;
   addMember: (member: MeetingMemberInfo) => void;
   removeMember: (userId: string) => void;
+  setMemberProducer: (
+    userId: string,
+    type: 'cam' | 'mic',
+    info: MemberProviderInfo | null,
+  ) => void;
   setScreenSharer: (sharer: { id: string; nickname: string } | null) => void;
   setSpeaking: (
     userId: string,
@@ -78,6 +86,7 @@ interface MeetingActions {
 export const useMeetingStore = create<MeetingState & MeetingActions>((set) => ({
   media: INITIAL_MEDIA_STATE,
   members: {},
+  memberProducers: {},
   memberStreams: {},
   hasNewChat: false,
   screenSharer: null,
@@ -104,9 +113,20 @@ export const useMeetingStore = create<MeetingState & MeetingActions>((set) => ({
       );
       const newOrderedIds = members.map((m) => m.user_id);
 
+      const newProducersMap: Record<
+        string,
+        { cam?: MemberProviderInfo; mic?: MemberProviderInfo }
+      > = {};
+      members.forEach((m) => {
+        newProducersMap[m.user_id] = {};
+        if (m.cam) newProducersMap[m.user_id].cam = m.cam;
+        if (m.mic) newProducersMap[m.user_id].mic = m.mic;
+      });
+
       return {
         members: newMembersMap,
         orderedMemberIds: newOrderedIds,
+        memberProducers: newProducersMap,
       };
     }),
   addMember: (member) =>
@@ -115,10 +135,19 @@ export const useMeetingStore = create<MeetingState & MeetingActions>((set) => ({
 
       const userId = member.user_id;
       const existingStream = state.memberStreams[member.user_id] || {};
+      const existingProducers = state.memberProducers[userId] || {};
 
       if (state.orderedMemberIds.includes(userId)) {
         return {
           members: { ...state.members, [userId]: member },
+          memberProducers: {
+            ...state.memberProducers,
+            [userId]: {
+              ...existingProducers,
+              cam: member.cam,
+              mic: member.mic,
+            },
+          },
         };
       }
 
@@ -137,6 +166,13 @@ export const useMeetingStore = create<MeetingState & MeetingActions>((set) => ({
           ...state.members,
           [userId]: member,
         },
+        memberProducers: {
+          ...state.memberProducers,
+          [userId]: {
+            cam: member.cam,
+            mic: member.mic,
+          },
+        },
         memberStreams: {
           ...state.memberStreams,
           [userId]: existingStream,
@@ -152,15 +188,26 @@ export const useMeetingStore = create<MeetingState & MeetingActions>((set) => ({
       delete nextMemberStreams[userId];
       const nextSpeakingMembers = { ...state.speakingMembers };
       delete nextSpeakingMembers[userId];
+      const nextProducers = { ...state.memberProducers };
+      delete nextProducers[userId];
 
       return {
         members: nextMembers,
+        memberProducers: nextProducers,
         memberStreams: nextMemberStreams,
         speakingMembers: nextSpeakingMembers,
         orderedMemberIds: state.orderedMemberIds.filter((id) => id !== userId),
         pinnedMemberIds: state.pinnedMemberIds.filter((id) => id !== userId),
         lastSpeakerId:
           state.lastSpeakerId === userId ? null : state.lastSpeakerId,
+      };
+    }),
+  setMemberProducer: (userId, type, info) =>
+    set((state) => {
+      const existing = state.memberProducers[userId] || {};
+      const updated = { ...existing, [type]: info };
+      return {
+        memberProducers: { ...state.memberProducers, [userId]: updated },
       };
     }),
   setScreenSharer: (sharer) => set(() => ({ screenSharer: sharer })),

--- a/frontend/src/types/meeting.ts
+++ b/frontend/src/types/meeting.ts
@@ -51,7 +51,7 @@ export interface ProviderToolInfo {
 }
 
 // 회의 멤버 관련 타입
-interface MemberProviderInfo {
+export interface MemberProviderInfo {
   provider_id: string;
   kind: 'audio' | 'video';
   type: 'mic' | 'cam';
@@ -85,7 +85,7 @@ export interface ProducerInfo {
   type: MediaType;
   nickname: string;
   is_paused: boolean;
-  is_restart : boolean;
+  is_restart: boolean;
 }
 
 export type MemberStream = Partial<Record<MediaType, MediaStream>>;

--- a/frontend/src/utils/__tests__/meeting.test.ts
+++ b/frontend/src/utils/__tests__/meeting.test.ts
@@ -1,9 +1,10 @@
 import { Consumer } from 'mediasoup-client/types';
-import { MeetingMemberInfo } from '@/types/meeting';
+import { MeetingMemberInfo, MemberProviderInfo } from '@/types/meeting';
 import {
   getAudioConsumerIds,
   getMembersPerPage,
   getVideoConsumerIds,
+  MemberProducers,
   reorderMembers,
 } from '@/utils/meeting';
 
@@ -73,11 +74,23 @@ describe('reorderMembers', () => {
 });
 
 describe('getVideoConsumerIds', () => {
-  const member = (id: string, camId?: string): MeetingMemberInfo =>
-    ({
-      user_id: id,
-      cam: camId ? { provider_id: camId } : undefined,
-    }) as MeetingMemberInfo;
+  const visible = (id: string): MeetingMemberInfo =>
+    ({ user_id: id }) as MeetingMemberInfo;
+  const producersFor = (
+    id: string,
+    camId?: string,
+  ): Record<string, MemberProducers> => {
+    const entry: Record<string, MemberProviderInfo> = {};
+    if (camId) {
+      entry.cam = {
+        provider_id: camId,
+        kind: 'video',
+        type: 'cam',
+        is_paused: false,
+      };
+    }
+    return { [id]: entry };
+  };
 
   const consumer = (id: string): Consumer =>
     ({
@@ -87,10 +100,8 @@ describe('getVideoConsumerIds', () => {
 
   it('visible 멤버 중 consumer가 없으면 newVideoConsumers에 포함된다', () => {
     const result = getVideoConsumerIds(
-      {
-        a: member('a', 'cam-a'),
-      },
-      [member('a', 'cam-a')],
+      producersFor('a', 'cam-a'),
+      [visible('a')],
       {},
     );
 
@@ -99,10 +110,8 @@ describe('getVideoConsumerIds', () => {
 
   it('visible 멤버의 consumer는 resume 대상이 된다', () => {
     const result = getVideoConsumerIds(
-      {
-        a: member('a', 'cam-a'),
-      },
-      [member('a', 'cam-a')],
+      producersFor('a', 'cam-a'),
+      [visible('a')],
       {
         'cam-a': consumer('consumer-a'),
       },
@@ -113,15 +122,9 @@ describe('getVideoConsumerIds', () => {
   });
 
   it('hidden 멤버의 consumer는 pause 대상이 된다', () => {
-    const result = getVideoConsumerIds(
-      {
-        a: member('a', 'cam-a'),
-      },
-      [],
-      {
-        'cam-a': consumer('consumer-a'),
-      },
-    );
+    const result = getVideoConsumerIds(producersFor('a', 'cam-a'), [], {
+      'cam-a': consumer('consumer-a'),
+    });
 
     expect(result.pauseConsumerIds).toEqual(['consumer-a']);
     expect(result.hiddenUserIds).toEqual(['a']);
@@ -129,17 +132,27 @@ describe('getVideoConsumerIds', () => {
 });
 
 describe('getAudioConsumerIds', () => {
-  const member = (id: string, micId?: string): MeetingMemberInfo =>
-    ({
-      user_id: id,
-      mic: micId ? { provider_id: micId } : undefined,
-    }) as MeetingMemberInfo;
+  const producersFor = (
+    id: string,
+    micId?: string,
+  ): Record<string, MemberProducers> => {
+    const entry: Record<string, MemberProviderInfo> = {};
+    if (micId) {
+      entry.mic = {
+        provider_id: micId,
+        kind: 'audio',
+        type: 'mic',
+        is_paused: false,
+      };
+    }
+    return { [id]: entry };
+  };
 
   it('consumer가 없는 mic만 newAudioConsumers에 포함된다', () => {
     const result = getAudioConsumerIds(
       {
-        a: member('a', 'mic-a'),
-        b: member('b', 'mic-b'),
+        ...producersFor('a', 'mic-a'),
+        ...producersFor('b', 'mic-b'),
       },
       {
         'mic-b': {} as Consumer,

--- a/frontend/src/utils/meeting.ts
+++ b/frontend/src/utils/meeting.ts
@@ -1,12 +1,20 @@
-import { ConsumerInfo, MeetingMemberInfo } from '@/types/meeting';
+import {
+  ConsumerInfo,
+  MeetingMemberInfo,
+  MemberProviderInfo,
+} from '@/types/meeting';
 import { Consumer, Transport } from 'mediasoup-client/types';
 
+export interface MemberProducers {
+  cam?: MemberProviderInfo | null;
+  mic?: MemberProviderInfo | null;
+}
+
 export const getVideoConsumerIds = (
-  members: Record<string, MeetingMemberInfo>,
+  producers: Record<string, MemberProducers>,
   visibleMembers: MeetingMemberInfo[],
   consumers: Record<string, Consumer>,
 ) => {
-  const allMembers = Object.values(members);
   const visibleIdsSet = new Set(visibleMembers.map((member) => member.user_id));
 
   const newVideoConsumers: string[] = [];
@@ -16,27 +24,21 @@ export const getVideoConsumerIds = (
   const visibleStreamTracks: { userId: string; track: MediaStreamTrack }[] = [];
   const hiddenUserIds: string[] = [];
 
-  allMembers.forEach((member) => {
-    const producerId = member.cam?.provider_id;
+  Object.entries(producers).forEach(([userId, prod]) => {
+    const producerId = prod.cam?.provider_id;
     if (!producerId) return;
 
     const consumer = consumers[producerId];
 
-    if (visibleIdsSet.has(member.user_id)) {
-      // 새로운 consume 대상
+    if (visibleIdsSet.has(userId)) {
       if (!consumer) {
         newVideoConsumers.push(producerId);
       } else {
-        // resume 대상 계산
         resumeConsumerIds.push(consumer.id);
-        visibleStreamTracks.push({
-          userId: member.user_id,
-          track: consumer.track,
-        });
+        visibleStreamTracks.push({ userId, track: consumer.track });
       }
     } else {
-      // pause 대상 계산
-      hiddenUserIds.push(member.user_id);
+      hiddenUserIds.push(userId);
       if (consumer) {
         pauseConsumerIds.push(consumer.id);
       }
@@ -53,16 +55,14 @@ export const getVideoConsumerIds = (
 };
 
 export const getAudioConsumerIds = (
-  members: Record<string, MeetingMemberInfo>,
+  producers: Record<string, MemberProducers>,
   consumers: Record<string, Consumer>,
 ) => {
-  const allMembers = Object.values(members);
   const newAudioConsumers: string[] = [];
 
-  allMembers.forEach((member) => {
-    const micId = member.mic?.provider_id;
+  Object.values(producers).forEach((prod) => {
+    const micId = prod.mic?.provider_id;
     if (!micId) return;
-
     if (!consumers[micId]) {
       newAudioConsumers.push(micId);
     }


### PR DESCRIPTION
## ✅ 작업 내용
- 상단바(`MemberVideoBar`)에서 참가자의 실시간 정보를 정적인 데이터인 `members`를 참고하는 방식에서, 실시간 송출 여부가 반영된 `memberProducers`를 참고하는 방식으로 구현하였습니다.

### 최종 데이터 구조
- `members`
  - 참가자의 id, 닉네임, 게스르 여부 등의 참가자의 기본 정보를 담은 정적 데이터
  - `cam`과 `mic`는 회의 참여 시 기존 사용자가 카메라나 마이크를 활성화하고 있었는지를 확인하기 위한 정보이며, 이후 카메라나 마이크가 활성화/비활성화 될 때 갱신되지 않음   <-- 이 부분을 실시간 정보 표시에 사용하다보니 이전의 동기화 문제가 발생했었습니다.
```ts
members: Record<string, MeetingMemberInfo>;

export interface MeetingMemberInfo {
  user_id: string;
  nickname: string;
  profile_path: string | null;
  is_guest: boolean;
  cam: MemberProviderInfo | null;
  mic: MemberProviderInfo | null;
}
```
---
- `memberProducers`
  - 참가자가 영상이나 음성을 활성화/비활성화 했을 때 갱신되는 Producer 정보가 저장되는 객체
  - `MemberProviderInfo`의 `is_paused` 갱신을 통해 활성화 여부를 실시간으로 동기화
```ts
memberProducers: Record<
  string,
  {
    cam?: MemberProviderInfo | null;
    mic?: MemberProviderInfo | null;
  }
>;
---
export interface MemberProviderInfo {
  provider_id: string;
  kind: 'audio' | 'video';
  type: 'mic' | 'cam';
  is_paused: boolean;
}
```
---
- `memberStreams`
  - 참가자의 실제 영상/음성 스트림 정보를 저장하는 객체
  - `Producer`를 통해 `Stream`을 한 번 설정하고, 여러 컴포넌트에서 사용하기 위해서 별도로 관리
```ts
memberStreams: Record<string, MemberStream>;

export type MemberStream = Partial<Record<MediaType, MediaStream>>;

export type MediaType = 'mic' | 'cam' | 'screen_video' | 'screen_audio';

```

---

## 🤔 리뷰 요구사항
- 기존에 발견하셨던 문제 상황이 정상적으로 해결되었는지 확인 부탁드립니다! ex) 새로 들어온 참가자의 캠/마이크 활성화 여부가 정상적으로 반영되지 않던 문제 등
- AI를 사용해 프로젝트의 전반적인 컨텍스트를 반영한 수정을 시도해보기 위해, `VSCode`에서 `Github Copilot`을 사용하여 코드 수정을 진행해보았습니다. 그러다보니 단계별로 작은 단위로 커밋을 하지 못하고, 여러 파일이 동시에 변경되었습니다. 결과적으로 커밋 하나의 단위가 조금 커졌습니다. 양해 부탁드립니다, 다음부터는 조금 더 단계적으로 해결해볼 수 있게 노력해보겠습니다!