### PR TITLE
코드에디터 Yjs 기반 CRDT 동기화 구조 리팩토링

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,8 @@
     "cz": "cz",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:ci": "jest --ci"
+    "test:ci": "jest --ci",
+    "test:codeeditor:load": "node scripts/codeeditor-load-test.mjs"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",

--- a/frontend/scripts/codeeditor-load-test.mjs
+++ b/frontend/scripts/codeeditor-load-test.mjs
@@ -1,0 +1,453 @@
+import { io } from 'socket.io-client';
+import * as Y from 'yjs';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const randomInt = (min, max) =>
+  Math.floor(Math.random() * (max - min + 1)) + min;
+const randomToken = () => {
+  const bag = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  return bag[randomInt(0, bag.length - 1)];
+};
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const FRONTEND_ROOT = path.resolve(__dirname, '..');
+
+function loadDotEnv() {
+  const envPath = path.join(FRONTEND_ROOT, '.env');
+  if (!fs.existsSync(envPath)) return;
+  const raw = fs.readFileSync(envPath, 'utf8');
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIndex = trimmed.indexOf('=');
+    if (eqIndex < 0) continue;
+    const key = trimmed.slice(0, eqIndex).trim();
+    if (!key || process.env[key] !== undefined) continue;
+    let value = trimmed.slice(eqIndex + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    process.env[key] = value;
+  }
+}
+
+function withAck(socket, event, payload, timeoutMs = 8000) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`ack timeout: ${event}`));
+    }, timeoutMs);
+
+    if (payload === undefined) {
+      socket.emit(event, (res) => {
+        clearTimeout(timer);
+        resolve(res);
+      });
+      return;
+    }
+
+    socket.emit(event, payload, (res) => {
+      clearTimeout(timer);
+      resolve(res);
+    });
+  });
+}
+
+function emitAndWaitEvent(socket, event, payload, waitEvent, timeoutMs = 8000) {
+  return new Promise((resolve, reject) => {
+    const onOk = (data) => {
+      clearTimeout(timer);
+      socket.off('room:error', onErr);
+      resolve(data);
+    };
+    const onErr = (err) => {
+      clearTimeout(timer);
+      socket.off(waitEvent, onOk);
+      reject(
+        new Error(
+          typeof err?.message === 'string' ? err.message : `${event} failed`,
+        ),
+      );
+    };
+    const timer = setTimeout(() => {
+      socket.off(waitEvent, onOk);
+      socket.off('room:error', onErr);
+      reject(new Error(`event timeout: ${event} -> ${waitEvent}`));
+    }, timeoutMs);
+
+    socket.once(waitEvent, onOk);
+    socket.once('room:error', onErr);
+    socket.emit(event, payload);
+  });
+}
+
+async function issueCodeeditorTickets({
+  signalingUrl,
+  signalingNamespace,
+  signalingPath,
+  roomCode,
+  roomPassword,
+  userCount,
+}) {
+  const tickets = [];
+
+  for (let i = 0; i < userCount; i++) {
+    const socket = io(`${signalingUrl}${signalingNamespace}`, {
+      path: signalingPath,
+      transports: ['websocket'],
+      reconnection: false,
+    });
+
+    await new Promise((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`signaling connect timeout: user=${i}`)),
+        8000,
+      );
+      socket.once('connect', () => {
+        clearTimeout(timer);
+        resolve();
+      });
+      socket.once('connect_error', (err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+    });
+
+    await emitAndWaitEvent(
+      socket,
+      'signaling:ws:join_room',
+      {
+        code: roomCode,
+        ...(roomPassword ? { password: roomPassword } : {}),
+        nickname: `load-bot-${String(i).padStart(2, '0')}`,
+      },
+      'room:joined',
+    );
+
+    let res;
+    if (i === 0) {
+      // 이전 비정상 종료 등으로 tool producer 상태가 남아 있을 수 있어 선제 정리 시도
+      try {
+        await withAck(
+          socket,
+          'signaling:ws:disconnect_tool',
+          { tool: 'codeeditor' },
+          3000,
+        );
+      } catch {
+        // no-op
+      }
+
+      try {
+        res = await withAck(socket, 'signaling:ws:open_codeeditor');
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (
+          message.includes('main producer') ||
+          message.includes('main_producer') ||
+          message.includes('이미 다른 main producer')
+        ) {
+          console.warn(
+            '[load-test] open_codeeditor blocked by existing main producer. fallback -> connect_tool',
+          );
+          res = await withAck(socket, 'signaling:ws:connect_tool', {
+            tool: 'codeeditor',
+          });
+        } else {
+          throw err;
+        }
+      }
+    } else {
+      res = await withAck(socket, 'signaling:ws:connect_tool', {
+        tool: 'codeeditor',
+      });
+    }
+
+    if (!res || typeof res.ticket !== 'string') {
+      socket.disconnect();
+      throw new Error(
+        `ticket issue failed: user=${i} response=${JSON.stringify(res)}`,
+      );
+    }
+
+    tickets.push(res.ticket);
+    socket.disconnect();
+  }
+
+  return tickets;
+}
+
+class VirtualClient {
+  constructor({ id, ticket, type, namespaceUrl, wsPath, roomCode }) {
+    this.id = id;
+    this.ticket = ticket;
+    this.type = type;
+    this.namespaceUrl = namespaceUrl;
+    this.wsPath = wsPath;
+    this.roomCode = roomCode;
+
+    this.doc = new Y.Doc();
+    this.text = this.doc.getText('monaco');
+    this.socket = null;
+    this.suppressSend = false;
+    this.connected = false;
+
+    this.syncReqCount = 0;
+    this.diffBytesReceived = 0;
+    this.remoteUpdatesReceived = 0;
+  }
+
+  emitReady(reason) {
+    if (!this.socket) return;
+    this.socket.emit('yjs-ready', {
+      state_vector: Y.encodeStateVector(this.doc),
+      reason,
+    });
+  }
+
+  emitSyncReq(reason) {
+    if (!this.socket) return;
+    this.syncReqCount += 1;
+    this.socket.emit('yjs-sync-req', {
+      state_vector: Y.encodeStateVector(this.doc),
+      reason,
+    });
+  }
+
+  manualSync(reason = 'MANUAL') {
+    this.emitSyncReq(reason);
+  }
+
+  applyRemote(update) {
+    this.suppressSend = true;
+    try {
+      Y.applyUpdate(
+        this.doc,
+        update instanceof Uint8Array ? update : new Uint8Array(update),
+      );
+    } catch {
+      this.emitSyncReq('REMOTE_APPLY_FAILED');
+    } finally {
+      this.suppressSend = false;
+    }
+  }
+
+  async connect() {
+    if (this.socket?.connected) return;
+
+    const socket = io(this.namespaceUrl, {
+      path: this.wsPath,
+      transports: ['websocket'],
+      auth: { token: this.ticket, type: this.type },
+      query: { room_code: this.roomCode },
+      reconnection: false,
+    });
+    this.socket = socket;
+
+    this.doc.on('update', (update) => {
+      if (!this.socket || !this.connected) return;
+      if (this.suppressSend) return;
+      this.socket.emit('yjs-update', { update });
+    });
+
+    socket.on('connect', () => {
+      this.connected = true;
+      this.emitReady('INIT');
+    });
+
+    socket.on('disconnect', () => {
+      this.connected = false;
+    });
+
+    socket.on('yjs-init', (payload) => {
+      this.applyRemote(payload.update);
+    });
+
+    socket.on('yjs-sync', (msg) => {
+      if (!msg?.ok || msg.type !== 'diff') return;
+      const bytes = msg.update?.byteLength ?? 0;
+      this.diffBytesReceived += bytes;
+      if (bytes > 0) {
+        this.applyRemote(msg.update);
+      }
+    });
+
+    socket.on('yjs-update', (msg) => {
+      const updates = msg?.updates ?? (msg?.update ? [msg.update] : []);
+      for (const update of updates) {
+        this.remoteUpdatesReceived += 1;
+        this.applyRemote(update);
+      }
+    });
+
+    await new Promise((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`client-${this.id} connect timeout`)),
+        8000,
+      );
+      socket.once('connect', () => {
+        clearTimeout(timer);
+        resolve();
+      });
+      socket.once('connect_error', (err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+    });
+  }
+
+  async disconnect() {
+    if (!this.socket) return;
+    this.socket.disconnect();
+    this.connected = false;
+    await sleep(100);
+  }
+
+  typeText(chars = 1) {
+    if (!this.connected) return;
+    const token = Array.from({ length: chars }, () => randomToken()).join('');
+    this.text.insert(this.text.length, token);
+  }
+
+  get value() {
+    return this.text.toString();
+  }
+}
+
+async function run() {
+  loadDotEnv();
+
+  const TOOL_BACKEND_URL =
+    process.env.TOOL_BACKEND_URL ??
+    process.env.NEXT_PUBLIC_TOOL_BACKEND_URL ??
+    'http://localhost:8000';
+  const WS_PATH =
+    process.env.TOOL_BACKEND_WS_PATH ??
+    process.env.NEXT_PUBLIC_TOOL_BACKEND_WEBSOCKET_PREFIX ??
+    '/tool/ws';
+
+  const SIGNALING_URL =
+    process.env.SIGNALING_URL ?? process.env.NEXT_PUBLIC_SERVER_URL;
+  const SIGNALING_NAMESPACE = process.env.SIGNALING_NAMESPACE ?? '/signal';
+  const SIGNALING_WS_PATH = process.env.SIGNALING_WS_PATH ?? '/api/ws/';
+
+  const ROOM_CODE =
+    process.env.NEXT_PUBLIC_ROOM_CODE ?? process.env.LOAD_TEST_ROOM_CODE;
+  const ROOM_PASSWORD =
+    process.env.ROOM_PASSWORD ?? process.env.LOAD_TEST_ROOM_PASSWORD;
+
+  const USER_COUNT = Number(process.env.USER_COUNT ?? 20);
+  const TEST_SECONDS = Number(process.env.TEST_SECONDS ?? 25);
+  const TYPE_INTERVAL_MS = Number(process.env.TYPE_INTERVAL_MS ?? 70);
+  const PARTITION_USER_INDEX = Number(process.env.PARTITION_USER_INDEX ?? 1);
+
+  if (!TOOL_BACKEND_URL || !WS_PATH || !SIGNALING_URL || !ROOM_CODE) {
+    console.log('', TOOL_BACKEND_URL);
+    console.log('', WS_PATH);
+    console.log('', SIGNALING_URL);
+    console.log('', ROOM_CODE);
+    throw new Error(
+      '필수 환경변수 누락: ROOM_CODE(or LOAD_TEST_ROOM_CODE), SIGNALING_URL(or NEXT_PUBLIC_SERVER_URL)',
+    );
+  }
+
+  console.log(`[load-test] issue tickets via signaling... room=${ROOM_CODE}`);
+  const tickets = await issueCodeeditorTickets({
+    signalingUrl: SIGNALING_URL,
+    signalingNamespace: SIGNALING_NAMESPACE,
+    signalingPath: SIGNALING_WS_PATH,
+    roomCode: ROOM_CODE,
+    roomPassword: ROOM_PASSWORD,
+    userCount: USER_COUNT,
+  });
+  console.log(`[load-test] tickets issued: ${tickets.length}`);
+
+  const namespaceUrl = `${TOOL_BACKEND_URL}/codeeditor`;
+  const users = Array.from({ length: USER_COUNT }, (_, idx) => {
+    return new VirtualClient({
+      id: idx,
+      ticket: tickets[idx],
+      type: idx === 0 ? 'main' : 'sub',
+      namespaceUrl,
+      wsPath: WS_PATH,
+      roomCode: ROOM_CODE,
+    });
+  });
+
+  console.log(`[load-test] connect ${USER_COUNT} users...`);
+  await Promise.all(users.map((u) => u.connect()));
+  console.log('[load-test] all connected');
+
+  let stop = false;
+  const typer = setInterval(() => {
+    if (stop) return;
+    const randomUser = users[randomInt(0, users.length - 1)];
+    randomUser.typeText(1);
+  }, TYPE_INTERVAL_MS);
+
+  const target = users[PARTITION_USER_INDEX];
+  const disconnectAfterMs = 4000;
+  const partitionMs = randomInt(5000, 10000);
+
+  await sleep(disconnectAfterMs);
+  console.log(
+    `[load-test] partition user=${PARTITION_USER_INDEX} for ${partitionMs}ms (network cut simulation)`,
+  );
+  await target.disconnect();
+
+  await sleep(partitionMs);
+  await target.connect();
+  target.typeText(1);
+  target.manualSync('MANUAL');
+  console.log(`[load-test] user=${PARTITION_USER_INDEX} reconnected`);
+
+  await sleep(
+    Math.max(0, TEST_SECONDS * 1000 - disconnectAfterMs - partitionMs),
+  );
+  stop = true;
+  clearInterval(typer);
+  await sleep(2000);
+
+  const base = users[0].value;
+  const mismatched = users.filter((u) => u.value !== base);
+  const totalSyncReq = users.reduce((acc, u) => acc + u.syncReqCount, 0);
+  const targetDiff = target.diffBytesReceived;
+
+  console.log('--- result ---');
+  console.log(`doc_length=${base.length}`);
+  console.log(`sync_req_total=${totalSyncReq}`);
+  console.log(`partition_user_sync_req=${target.syncReqCount}`);
+  console.log(`partition_user_diff_bytes=${targetDiff}`);
+  console.log(`mismatched_users=${mismatched.length}`);
+
+  await Promise.all(users.map((u) => u.disconnect()));
+
+  if (target.syncReqCount < 1) {
+    throw new Error(
+      '실패: partition 사용자에서 yjs-sync-req가 발생하지 않았습니다.',
+    );
+  }
+  if (targetDiff <= 0) {
+    throw new Error('실패: partition 사용자의 diff bytes가 0입니다.');
+  }
+  if (mismatched.length > 0) {
+    throw new Error(
+      `실패: 문서가 수렴하지 않았습니다. mismatched=${mismatched.length}`,
+    );
+  }
+
+  console.log('PASS: 20명 가상 사용자 시나리오에서 문서 수렴 확인');
+}
+
+run()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error('[load-test] failed:', err);
+    process.exit(1);
+  });

--- a/frontend/src/components/__tests__/code-editor/load-test.ts
+++ b/frontend/src/components/__tests__/code-editor/load-test.ts
@@ -1,0 +1,285 @@
+/* eslint-disable no-console */
+import { io, Socket } from 'socket.io-client';
+import * as Y from 'yjs';
+
+type SyncMsg =
+  | {
+      type: 'diff';
+      ok: true;
+      update: ArrayBuffer | Uint8Array;
+      server_state_vector?: ArrayBuffer | Uint8Array;
+      origin: 'SYNC_REQ' | 'INIT';
+    }
+  | {
+      type: 'error';
+      ok: false;
+      code: 'BAD_PAYLOAD' | 'ROOM_NOT_FOUND' | 'INTERNAL';
+      message?: string;
+      origin?: 'SYNC_REQ' | 'INIT';
+    };
+
+type ReadyReason = 'INIT' | 'MANUAL' | 'UNKNOWN' | 'REMOTE_APPLY_FAILED' | 'SERVER_HINT';
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const randomInt = (min: number, max: number) =>
+  Math.floor(Math.random() * (max - min + 1)) + min;
+
+const randomToken = () => {
+  const bag = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  return bag[randomInt(0, bag.length - 1)];
+};
+
+class VirtualClient {
+  readonly id: number;
+  readonly doc: Y.Doc;
+  readonly text: Y.Text;
+  private readonly ticket: string;
+  private readonly type: 'main' | 'sub';
+  private readonly namespaceUrl: string;
+  private readonly wsPath: string;
+  private readonly roomCode: string;
+  private suppressSend = false;
+  private socket: Socket | null = null;
+
+  syncReqCount = 0;
+  diffBytesReceived = 0;
+  remoteUpdatesReceived = 0;
+  connected = false;
+
+  constructor(params: {
+    id: number;
+    ticket: string;
+    type: 'main' | 'sub';
+    namespaceUrl: string;
+    wsPath: string;
+    roomCode: string;
+  }) {
+    this.id = params.id;
+    this.ticket = params.ticket;
+    this.type = params.type;
+    this.namespaceUrl = params.namespaceUrl;
+    this.wsPath = params.wsPath;
+    this.roomCode = params.roomCode;
+
+    this.doc = new Y.Doc();
+    this.text = this.doc.getText('monaco');
+  }
+
+  private emitReady(reason: ReadyReason) {
+    if (!this.socket) return;
+    this.socket.emit('yjs-ready', {
+      state_vector: Y.encodeStateVector(this.doc),
+      reason,
+    });
+  }
+
+  private emitSyncReq(reason: ReadyReason) {
+    if (!this.socket) return;
+    this.syncReqCount += 1;
+    this.socket.emit('yjs-sync-req', {
+      state_vector: Y.encodeStateVector(this.doc),
+      reason,
+    });
+  }
+
+  manualSync(reason: ReadyReason = 'MANUAL') {
+    this.emitSyncReq(reason);
+  }
+
+  private applyRemote(update: ArrayBuffer | Uint8Array) {
+    this.suppressSend = true;
+    try {
+      Y.applyUpdate(this.doc, update instanceof Uint8Array ? update : new Uint8Array(update));
+    } catch {
+      this.emitSyncReq('REMOTE_APPLY_FAILED');
+    } finally {
+      this.suppressSend = false;
+    }
+  }
+
+  async connect() {
+    if (this.socket?.connected) return;
+
+    const socket = io(this.namespaceUrl, {
+      path: this.wsPath,
+      transports: ['websocket'],
+      auth: { token: this.ticket, type: this.type },
+      query: { room_code: this.roomCode },
+      reconnection: false,
+    });
+    this.socket = socket;
+
+    this.doc.on('update', (update) => {
+      if (!this.socket || !this.connected) return;
+      if (this.suppressSend) return;
+      this.socket.emit('yjs-update', { update });
+    });
+
+    socket.on('connect', () => {
+      this.connected = true;
+      this.emitReady('INIT');
+    });
+
+    socket.on('disconnect', () => {
+      this.connected = false;
+    });
+
+    socket.on('yjs-init', (payload: { update: ArrayBuffer | Uint8Array }) => {
+      this.applyRemote(payload.update);
+    });
+
+    socket.on('yjs-sync', (msg: SyncMsg) => {
+      if (!msg.ok) return;
+      if (msg.type !== 'diff') return;
+      const bytes =
+        msg.update instanceof Uint8Array ? msg.update.byteLength : msg.update.byteLength;
+      this.diffBytesReceived += bytes;
+      if (bytes > 0) {
+        this.applyRemote(msg.update);
+      }
+    });
+
+    socket.on('yjs-update', (msg: { update?: ArrayBuffer | Uint8Array; updates?: unknown[] }) => {
+      const updates = msg.updates ?? (msg.update ? [msg.update] : []);
+      for (const update of updates) {
+        this.remoteUpdatesReceived += 1;
+        this.applyRemote(update as ArrayBuffer | Uint8Array);
+      }
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error(`client-${this.id} connect timeout`)), 8000);
+      socket.once('connect', () => {
+        clearTimeout(timer);
+        resolve();
+      });
+      socket.once('connect_error', (err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+    });
+  }
+
+  async disconnect() {
+    if (!this.socket) return;
+    this.socket.disconnect();
+    this.connected = false;
+    await sleep(100);
+  }
+
+  async reconnect() {
+    await this.disconnect();
+    await this.connect();
+  }
+
+  typeText(chars = 1) {
+    if (!this.connected) return;
+    const token = Array.from({ length: chars }, () => randomToken()).join('');
+    this.text.insert(this.text.length, token);
+  }
+
+  get value() {
+    return this.text.toString();
+  }
+}
+
+async function run() {
+  const TOOL_BACKEND_URL = process.env.TOOL_BACKEND_URL ?? process.env.NEXT_PUBLIC_TOOL_BACKEND_URL;
+  const WS_PATH =
+    process.env.TOOL_BACKEND_WS_PATH ?? process.env.NEXT_PUBLIC_TOOL_BACKEND_WEBSOCKET_PREFIX;
+  const ROOM_CODE = process.env.ROOM_CODE ?? 'load-test-room';
+  const TICKET = process.env.CODEEDITOR_TICKET;
+
+  const USER_COUNT = Number(process.env.USER_COUNT ?? 20);
+  const TEST_SECONDS = Number(process.env.TEST_SECONDS ?? 25);
+  const TYPE_INTERVAL_MS = Number(process.env.TYPE_INTERVAL_MS ?? 70);
+  const PARTITION_USER_INDEX = Number(process.env.PARTITION_USER_INDEX ?? 1);
+
+  if (!TOOL_BACKEND_URL || !WS_PATH || !TICKET) {
+    throw new Error(
+      '필수 환경변수 누락: TOOL_BACKEND_URL(or NEXT_PUBLIC_TOOL_BACKEND_URL), TOOL_BACKEND_WS_PATH(or NEXT_PUBLIC_TOOL_BACKEND_WEBSOCKET_PREFIX), CODEEDITOR_TICKET',
+    );
+  }
+
+  const namespaceUrl = `${TOOL_BACKEND_URL}/codeeditor`;
+  const users = Array.from({ length: USER_COUNT }, (_, idx) => {
+    return new VirtualClient({
+      id: idx,
+      ticket: TICKET,
+      type: idx === 0 ? 'main' : 'sub',
+      namespaceUrl,
+      wsPath: WS_PATH,
+      roomCode: ROOM_CODE,
+    });
+  });
+
+  console.log(`[load-test] connect ${USER_COUNT} users...`);
+  await Promise.all(users.map((u) => u.connect()));
+  console.log('[load-test] all connected');
+
+  let stop = false;
+  const typer = setInterval(() => {
+    if (stop) return;
+    const randomUser = users[randomInt(0, users.length - 1)];
+    randomUser.typeText(1);
+  }, TYPE_INTERVAL_MS);
+
+  const target = users[PARTITION_USER_INDEX];
+  const disconnectAfterMs = 4000;
+  const partitionMs = randomInt(5000, 10000);
+
+  await sleep(disconnectAfterMs);
+  console.log(
+    `[load-test] partition user=${PARTITION_USER_INDEX} for ${partitionMs}ms (network cut simulation)`,
+  );
+  await target.disconnect();
+
+  await sleep(partitionMs);
+  await target.connect();
+  target.typeText(1);
+  target.manualSync('MANUAL');
+  console.log(`[load-test] user=${PARTITION_USER_INDEX} reconnected`);
+
+  await sleep(Math.max(0, TEST_SECONDS * 1000 - disconnectAfterMs - partitionMs));
+  stop = true;
+  clearInterval(typer);
+
+  // settle
+  await sleep(2000);
+
+  const base = users[0].value;
+  const mismatched = users.filter((u) => u.value !== base);
+  const totalSyncReq = users.reduce((acc, u) => acc + u.syncReqCount, 0);
+  const targetDiff = target.diffBytesReceived;
+
+  console.log('--- result ---');
+  console.log(`doc_length=${base.length}`);
+  console.log(`sync_req_total=${totalSyncReq}`);
+  console.log(`partition_user_sync_req=${target.syncReqCount}`);
+  console.log(`partition_user_diff_bytes=${targetDiff}`);
+  console.log(`mismatched_users=${mismatched.length}`);
+
+  await Promise.all(users.map((u) => u.disconnect()));
+
+  if (target.syncReqCount < 1) {
+    throw new Error('실패: partition 사용자에서 yjs-sync-req가 발생하지 않았습니다.');
+  }
+  if (targetDiff <= 0) {
+    throw new Error('실패: partition 사용자의 diff bytes가 0입니다.');
+  }
+  if (mismatched.length > 0) {
+    throw new Error(`실패: 문서가 수렴하지 않았습니다. mismatched=${mismatched.length}`);
+  }
+
+  console.log('PASS: 20명 가상 사용자 시나리오에서 문서 수렴 확인');
+}
+
+run()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error('[load-test] failed:', err);
+    process.exit(1);
+  });

--- a/frontend/src/components/code-editor/CodeEditor.tsx
+++ b/frontend/src/components/code-editor/CodeEditor.tsx
@@ -205,6 +205,13 @@ export default function CodeEditor({
       if (updates.length === 0) return;
 
       const merged = Y.mergeUpdates(updates);
+
+      console.log(
+        'sync payload size (client->server):',
+        merged.byteLength,
+        'bytes',
+      );
+
       socket.emit('yjs-update', {
         update: merged,
         ts: Date.now(),
@@ -255,6 +262,12 @@ export default function CodeEditor({
 
     // Socket -> Yjs (init)
     const onYjsInit = (data: YjsInitPayload) => {
+      console.log(
+        'initial sync payload size:',
+        data.update.byteLength,
+        'bytes',
+      );
+
       syncLog(
         'yjs-init',
         {
@@ -283,6 +296,8 @@ export default function CodeEditor({
       }
 
       if (msg.type === 'diff') {
+        console.log('sync diff payload size:', msg.update.byteLength, 'bytes');
+
         if (msg.update.byteLength > 0) {
           applyUpdatesNoSend([msg.update]);
         }
@@ -295,6 +310,10 @@ export default function CodeEditor({
     const onYjsRemoteUpdate = (msg: YjsRemoteUpdate) => {
       const updates = msg.updates ?? (msg.update ? [msg.update] : []);
       if (updates.length === 0) return;
+
+      // payload size 디버깅용
+      const size = updates.reduce((acc, u) => acc + u.byteLength, 0);
+      console.log('sync payload size (server->client):', size, 'bytes');
 
       // latency 측정
       if (msg.ts) {

--- a/frontend/src/components/code-editor/CodeEditor.tsx
+++ b/frontend/src/components/code-editor/CodeEditor.tsx
@@ -40,6 +40,7 @@ export default function CodeEditor({
     ydoc: Y.Doc;
     awareness: awarenessProtocol.Awareness;
   } | null>(null);
+  const latencySamplesRef = useRef<number[]>([]);
 
   const cursorCollectionsRef = useRef<
     Map<number, monaco.editor.IEditorDecorationsCollection>
@@ -51,18 +52,12 @@ export default function CodeEditor({
   const mergeTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   const BUFFER_WINDOW_MS = 50; // 로컬 update를 모아서 한번에 전송하는 time window (50ms)
-  const MAX_PENDING_UPDATES = 10; // ack를 기다리는 동안 동시에 쌓아둘 수 있는 최대 update 개수
-  const MAX_MERGED_BYTES = 8 * 1024; // 8KB (한번에 병합해서 보낼 update 데이터의 최대 크기)
 
   // 동기화 관련 refs
   const syncState = useRef({
-    lastSeq: 0,
-    awaitingAck: false,
     suppressSend: false,
-    dirty: false,
     syncReqInFlight: false,
     readySent: false,
-    lastSendAt: 0, // RTT 측정용
   });
 
   // states
@@ -167,21 +162,27 @@ export default function CodeEditor({
           message: 'Yjs 트랜잭션 적용 실패',
           extra: { updateCount: updates.length },
         });
+        return false;
       } finally {
         syncState.current.suppressSend = false;
       }
+
+      return true;
     };
 
-    const requestSync = (reason: YjsSyncReqPayload['reason'] = 'SEQ_GAP') => {
+    const requestSync = (reason: YjsSyncReqPayload['reason'] = 'UNKNOWN') => {
       if (syncState.current.syncReqInFlight) return;
+      if (!providerRef.current) return;
 
-      // [모니터링] 시퀀스 갭 발생 시 Sentry 카운트 증가
-      Sentry.metrics.count('editor.sync.gap', 1, { attributes: { reason } });
+      Sentry.metrics.count('editor.sync.repair_request', 1, {
+        attributes: { reason },
+      });
 
       syncState.current.syncReqInFlight = true;
+      const stateVector = Y.encodeStateVector(providerRef.current.ydoc);
 
       socket.emit('yjs-sync-req', {
-        last_seq: syncState.current.lastSeq,
+        state_vector: stateVector,
         reason,
       } satisfies YjsSyncReqPayload);
 
@@ -189,36 +190,6 @@ export default function CodeEditor({
       setTimeout(() => {
         syncState.current.syncReqInFlight = false;
       }, 1500);
-    };
-
-    const sendFullStateOnce = () => {
-      if (!providerRef.current) return;
-
-      // ack 기다리는 중이면 큐 쌓지 말고 dirty만 표시
-      if (syncState.current.awaitingAck) {
-        syncState.current.dirty = true;
-        return;
-      }
-
-      const full = Y.encodeStateAsUpdate(providerRef.current.ydoc);
-      syncState.current.awaitingAck = true;
-      syncState.current.dirty = false;
-      syncState.current.lastSendAt = performance.now(); // 측정용
-
-      const payload: YjsUpdateClientPayload = {
-        last_seq: syncState.current.lastSeq,
-        update: full,
-      };
-      socket.emit('yjs-update', payload);
-
-      syncLog(
-        'emit-full-state',
-        {
-          lastSeq: syncState.current.lastSeq,
-          bytes: full.length,
-        },
-        'info',
-      );
     };
 
     const clearPendingUpdates = () => {
@@ -234,29 +205,15 @@ export default function CodeEditor({
       if (updates.length === 0) return;
 
       const merged = Y.mergeUpdates(updates);
+      socket.emit('yjs-update', {
+        update: merged,
+        ts: Date.now(),
+      } satisfies YjsUpdateClientPayload);
 
-      // 사이즈 초과 시 full-state fallback
-      if (merged.byteLength > MAX_MERGED_BYTES) {
-        syncLog(
-          'sync.merge.fallback.full_state',
-          { mergedBytes: merged.byteLength },
-          'warning',
-        );
-        sendFullStateOnce();
-      } else {
-        syncState.current.awaitingAck = true;
-        syncState.current.lastSendAt = performance.now();
-
-        socket.emit('yjs-update', {
-          last_seq: syncState.current.lastSeq,
-          update: merged,
-        } satisfies YjsUpdateClientPayload);
-
-        syncLog('sync.emit.merged_update', {
-          updates: updates.length,
-          bytes: merged.byteLength,
-        });
-      }
+      syncLog('sync.emit.merged_update', {
+        updates: updates.length,
+        bytes: merged.byteLength,
+      });
 
       clearPendingUpdates();
     };
@@ -301,17 +258,12 @@ export default function CodeEditor({
       syncLog(
         'yjs-init',
         {
-          seq: data.seq,
           size: data.update?.byteLength,
         },
         'info',
       );
 
       applyUpdatesNoSend([data.update]);
-      syncState.current.lastSeq = data.seq;
-
-      syncState.current.awaitingAck = false;
-      syncState.current.dirty = false;
       syncState.current.syncReqInFlight = false;
     };
     socket.on('yjs-init', onYjsInit);
@@ -326,128 +278,39 @@ export default function CodeEditor({
           extra: { payload: msg },
         });
 
-        syncState.current.awaitingAck = false;
         syncState.current.syncReqInFlight = false;
         return;
       }
 
-      if (msg.type === 'ack') {
-        const rtt = performance.now() - syncState.current.lastSendAt;
-        syncLog('sync.ack.received', {
-          serverSeq: msg.server_seq,
-          rtt,
-          dirtyAfterAck: syncState.current.dirty,
-        });
-
-        syncState.current.lastSeq = Math.max(
-          syncState.current.lastSeq,
-          msg.server_seq,
-        );
-        syncState.current.awaitingAck = false;
+      if (msg.type === 'diff') {
+        if (msg.update.byteLength > 0) {
+          applyUpdatesNoSend([msg.update]);
+        }
         syncState.current.syncReqInFlight = false;
-
-        // ack 기다리는 동안 더 입력이 있었다면 full-state 한 방
-        if (syncState.current.dirty) {
-          // sendFullStateOnce();
-
-          if (pendingUpdatesRef.current.length > 0) {
-            syncLog(
-              'sync.flush.after_ack',
-              { pending: pendingUpdatesRef.current.length },
-              'info',
-            );
-            emitMergedUpdates();
-          }
-        }
-        return;
-      }
-
-      if (msg.type === 'full' || msg.type === 'patch') {
-        const rtt = performance.now() - syncState.current.lastSendAt;
-        // Sentry Distribution으로 RTT 분포 측정
-        Sentry.metrics.distribution('editor.sync.rtt', rtt, {
-          unit: 'millisecond',
-        });
-
-        // 500ms 이상 지연 시 함께 기록
-        if (rtt > 500) {
-          syncLog(
-            'high-latency',
-            {
-              rtt,
-              type: msg.type,
-            },
-            'warning',
-          );
-        }
-
-        applyUpdatesNoSend(msg.type === 'full' ? [msg.update] : msg.updates);
-
-        const syncLatestSeq = msg.type === 'full' ? msg.server_seq : msg.to_seq;
-
-        syncState.current.lastSeq = Math.max(
-          syncState.current.lastSeq,
-          syncLatestSeq,
-        );
-
-        syncState.current.awaitingAck = false;
-        syncState.current.syncReqInFlight = false;
-
-        // UPDATE_REJECTED인 경우만 재전송(A안)
-        if (msg.origin === 'UPDATE_REJECTED') {
-          sendFullStateOnce();
-        }
         return;
       }
     };
     socket.on('yjs-sync', onYjsSync);
 
-    /**
-     * ---- Socket -> Yjs (remote updates) ----
-     * 단일/배치 모두 커버 + seq gap이면 sync-req
-     */
     const onYjsRemoteUpdate = (msg: YjsRemoteUpdate) => {
-      // 단일
-      if ('seq' in msg) {
-        const expected = syncState.current.lastSeq + 1;
-        if (msg.seq !== expected) {
-          syncLog(
-            'sync.anomaly.seq_gap',
-            {
-              expected,
-              got: msg.seq,
-              awaitingAck: syncState.current.awaitingAck,
-              dirty: syncState.current.dirty,
-            },
-            'error',
-          );
+      const updates = msg.updates ?? (msg.update ? [msg.update] : []);
+      if (updates.length === 0) return;
 
-          requestSync('SEQ_GAP');
-          return;
-        }
+      // latency 측정
+      if (msg.ts) {
+        const latency = Date.now() - msg.ts;
+        latencySamplesRef.current.push(latency);
 
-        syncLog('sync.remote.apply', {
-          seq: msg.seq,
-          bytes: msg.update.byteLength,
-        });
-
-        applyUpdatesNoSend([msg.update]);
-        syncState.current.lastSeq = msg.seq;
-        syncState.current.syncReqInFlight = false;
-        return;
+        // 디버깅용
+        console.log('update latency:', latency, 'ms');
       }
 
-      // 배치
-      const expectedFrom = syncState.current.lastSeq + 1;
-      if (msg.from_seq !== expectedFrom) {
-        requestSync('SEQ_GAP');
-        return;
+      const ok = applyUpdatesNoSend(updates);
+      if (!ok) {
+        requestSync('REMOTE_APPLY_FAILED');
       }
-
-      applyUpdatesNoSend(msg.updates);
-      syncState.current.lastSeq = msg.to_seq;
-      syncState.current.syncReqInFlight = false;
     };
+
     socket.on('yjs-update', onYjsRemoteUpdate);
 
     /**
@@ -455,70 +318,23 @@ export default function CodeEditor({
      */
     if (!syncState.current.readySent) {
       syncState.current.readySent = true;
-      socket.emit('yjs-ready');
+      socket.emit('yjs-ready', {
+        state_vector: Y.encodeStateVector(ydoc),
+        reason: 'INIT',
+      } satisfies YjsSyncReqPayload);
     }
 
     //---- Yjs -> Socket (local updates) ----
     const onYdocUpdate = (update: Uint8Array, origin: unknown) => {
-      // 로컬 입력이 실제로 얼마나 발생했는지, ack 대기 중에 몇 개 누적됐는지
       syncLog('sync.local.update', {
         bytes: update.length,
-        awaitingAck: syncState.current.awaitingAck,
-        dirty: syncState.current.dirty,
-        lastSeq: syncState.current.lastSeq,
       });
 
       if (origin === remoteOrigin) return;
       if (syncState.current.suppressSend) return;
 
-      syncState.current.dirty = true;
-
-      // ack 기다리는 중이면 쌓지 않고 표시만
-      // if (syncState.current.awaitingAck) { // 이게 사실상 full-state 빈도 높은 이유
-      // return;
-      // }
-      if (syncState.current.awaitingAck) {
-        pendingUpdatesRef.current.push(update);
-
-        syncLog(
-          'sync.local.buffered',
-          {
-            pending: pendingUpdatesRef.current.length,
-            bytes: update.length,
-          },
-          'warning',
-        );
-
-        // overflow 방어
-        if (pendingUpdatesRef.current.length >= MAX_PENDING_UPDATES) {
-          syncLog(
-            'sync.buffer.overflow',
-            { pending: pendingUpdatesRef.current.length },
-            'error',
-          );
-          sendFullStateOnce();
-          clearPendingUpdates();
-        } else {
-          scheduleMergeEmit();
-        }
-
-        return;
-      }
-
-      syncState.current.awaitingAck = true;
-      syncState.current.dirty = false;
-      syncState.current.lastSendAt = performance.now(); // [측정 시작]
-
-      const payload: YjsUpdateClientPayload = {
-        last_seq: syncState.current.lastSeq,
-        update,
-      };
-      socket.emit('yjs-update', payload);
-
-      syncLog('sync.emit.update', {
-        seq: syncState.current.lastSeq,
-        bytes: update.length,
-      });
+      pendingUpdatesRef.current.push(update);
+      scheduleMergeEmit();
     };
     ydoc.on('update', onYdocUpdate);
 
@@ -584,7 +400,7 @@ export default function CodeEditor({
 
     const updatePresenterState = (states: Map<number, AwarenessState>) => {
       const presenter = [...states.entries()].find(
-        ([_, state]) => state.user?.role === 'presenter',
+        ([, state]) => state.user?.role === 'presenter',
       );
 
       const presenterId = presenter?.[0] ?? null;

--- a/frontend/src/instrumentation-client.ts
+++ b/frontend/src/instrumentation-client.ts
@@ -17,6 +17,10 @@ Sentry.init({
   debug: !isProd,
   enabled: true,
 
+  _experiments: {
+    metrics: true,
+  },
+
   // Enable logs to be sent to Sentry
   enableLogs: true,
 

--- a/frontend/src/types/code-editor.ts
+++ b/frontend/src/types/code-editor.ts
@@ -27,36 +27,24 @@ export type AwarenessState = {
 
 export type YjsInitPayload = {
   update: ArrayBuffer;
-  seq: number;
+  state_vector?: ArrayBuffer;
   origin?: 'INIT';
 };
 
-export type YjsRemoteUpdateSingle = { seq: number; update: ArrayBuffer };
-export type YjsRemoteUpdateBatch = {
-  from_seq: number;
-  to_seq: number;
-  updates: ArrayBuffer[];
+export type YjsRemoteUpdate = {
+  update?: ArrayBuffer;
+  updates?: ArrayBuffer[];
+  ts?: number;
 };
-export type YjsRemoteUpdate = YjsRemoteUpdateSingle | YjsRemoteUpdateBatch;
 
-export type YjsSyncOrigin = 'UPDATE_REJECTED' | 'SYNC_REQ' | 'INIT';
+export type YjsSyncOrigin = 'SYNC_REQ' | 'INIT';
 
 export type YjsSyncServerPayload =
-  | { type: 'ack'; ok: true; server_seq: number; origin?: YjsSyncOrigin }
   | {
-      type: 'patch';
+      type: 'diff';
       ok: true;
-      from_seq: number;
-      to_seq: number;
-      updates: ArrayBuffer[];
-      server_seq: number;
-      origin: YjsSyncOrigin;
-    }
-  | {
-      type: 'full';
-      ok: true;
-      server_seq: number;
       update: ArrayBuffer;
+      server_state_vector?: ArrayBuffer;
       origin: YjsSyncOrigin;
     }
   | {
@@ -68,12 +56,17 @@ export type YjsSyncServerPayload =
     };
 
 export type YjsSyncReqPayload = {
-  last_seq: number;
-  reason?: 'SEQ_GAP' | 'MANUAL' | 'UNKNOWN' | 'INIT';
+  state_vector: Uint8Array;
+  reason?:
+    | 'MANUAL'
+    | 'UNKNOWN'
+    | 'INIT'
+    | 'REMOTE_APPLY_FAILED'
+    | 'SERVER_HINT';
 };
 
 export type YjsUpdateClientPayload = {
-  last_seq: number;
   update?: Uint8Array;
   updates?: Uint8Array[];
+  ts?: number;
 };

--- a/frontend/src/types/error.ts
+++ b/frontend/src/types/error.ts
@@ -1,0 +1,8 @@
+export const ErrorType = {
+  HTTP: 'http',
+  SOCKET: 'socket',
+  SYNC: 'sync',
+  MEDIA: 'media',
+  EDITOR: 'editor',
+  AUTH: 'auth',
+} as const;

--- a/frontend/src/utils/logging.ts
+++ b/frontend/src/utils/logging.ts
@@ -1,0 +1,65 @@
+import * as Sentry from '@sentry/nextjs';
+
+export function captureError(params: {
+  error: unknown;
+  type: string;
+  message: string;
+  tags?: Record<string, string>;
+  extra?: Record<string, unknown>;
+}) {
+  Sentry.withScope((scope) => {
+    scope.setTag('error_type', params.type);
+
+    if (params.tags) scope.setTags(params.tags);
+    if (params.extra) scope.setContext('details', params.extra);
+
+    // Fingerprint를 설정하면 Sentry에서 이슈를 그룹화하는 방식을 직접 제어 가능
+    scope.setFingerprint([params.type, params.message]);
+
+    const exception =
+      params.error instanceof Error ? params.error : new Error(params.message);
+    Sentry.captureException(exception);
+  });
+}
+
+export function socketBreadcrumb(
+  event: string,
+  data?: unknown,
+  level: 'info' | 'warning' | 'error' = 'info',
+) {
+  Sentry.addBreadcrumb({
+    category: 'socket',
+    message: event,
+    data: data ? { payload: data } : undefined,
+    level,
+  });
+}
+
+type Level = 'info' | 'warning' | 'error';
+
+export function syncLog(
+  name: string,
+  data: Record<string, any> = {},
+  level: Level = 'info',
+) {
+  // breadcrumb (타임라인)
+  Sentry.addBreadcrumb({
+    category: 'yjs-sync',
+    message: name,
+    level,
+    data,
+  });
+
+  // anomaly / simulation 은 event로도 쏘기
+  if (level !== 'info') {
+    Sentry.captureMessage(`[SYNC] ${name}`, {
+      level,
+      extra: data,
+    });
+  }
+
+  if (process.env.NODE_ENV === 'development') {
+    // eslint-disable-next-line no-console
+    console.log(`🧩 [${name}]`, data);
+  }
+}

--- a/rep/tool_backend/src/codeeditor/codeeditor.gateway.ts
+++ b/rep/tool_backend/src/codeeditor/codeeditor.gateway.ts
@@ -27,6 +27,7 @@ import {
 import { PrometheusService } from '@/infra/metric/prometheus/prometheus.service';
 import { WsMetricsInterceptor } from '@/infra/metric/prometheus/prometheus.intercepter';
 
+const ROOM_EVICT_DELAY_MS = 30_000;
 
 @UseInterceptors(WsMetricsInterceptor)
 @WebSocketGateway({
@@ -43,14 +44,15 @@ export class CodeeditorWebsocketGateway implements OnGatewayInit, OnGatewayConne
   @WebSocketServer()
   private readonly server: Server;
 
-  private readonly logger = new Logger();
+  private readonly logger = new Logger(CodeeditorWebsocketGateway.name);
+  private readonly roomEvictionTimers = new Map<string, NodeJS.Timeout>();
 
   constructor(
     private readonly codeeditorService: CodeeditorService,
     private readonly kafkaService: KafkaService,
     private readonly codeeditorRepo: CodeeditorRepository,
     @Inject(CODEEDITOR_WEBSOCKET) private readonly codeeditorSocket: CodeeditorWebsocket,
-    private readonly prom : PrometheusService
+    private readonly prom: PrometheusService,
   ) {}
 
   // 연결을 했을때
@@ -68,7 +70,6 @@ export class CodeeditorWebsocketGateway implements OnGatewayInit, OnGatewayConne
 
         // data 추가
         socket.data.payload = payload;
-        this.logger.log('웹소켓 준비되었습니다.');
         return next();
       } catch (err) {
         this.logger.error(err);
@@ -79,18 +80,25 @@ export class CodeeditorWebsocketGateway implements OnGatewayInit, OnGatewayConne
 
   // 연결 완료 후
   async handleConnection(client: Socket) {
-    const ns : string = client.nsp.name; // 여기서는 /signal이 될 예정이다.
+    const ns: string = client.nsp.name; // 여기서는 /signal이 될 예정이다.
     this.prom.wsConnectionsCurrent.labels(ns).inc();
     this.prom.wsConnectionsTotal.labels(ns).inc();
-    
+
     const payload: ToolBackendPayload = client.data.payload;
     if (!payload) {
       client.disconnect(true);
       return;
     }
-    const roomName = this.codeeditorService.makeNamespace(payload.room_id); // 방가입
+
+    const roomName = this.codeeditorService.makeNamespace(payload.room_id);
     await client.join(roomName);
     client.data.roomName = roomName;
+
+    const existingTimer = this.roomEvictionTimers.get(roomName);
+    if (existingTimer) {
+      clearTimeout(existingTimer);
+      this.roomEvictionTimers.delete(roomName);
+    }
 
     if (payload.clientType === 'main') {
       // main이 불러오면 ydoc에 있는 캐시도 자동으로 불러오게 한다.
@@ -103,7 +111,7 @@ export class CodeeditorWebsocketGateway implements OnGatewayInit, OnGatewayConne
         ticket: payload.ticket,
         at: Date.now(), // 현재 보낸 시간
       });
-    };
+    }
 
     client.emit(CODEEDITOR_CLIENT_EVENT_NAME.PERMISSION, { ok: true });
   }
@@ -113,22 +121,36 @@ export class CodeeditorWebsocketGateway implements OnGatewayInit, OnGatewayConne
     const ns = client.nsp.name;
     this.prom.wsConnectionsCurrent.labels(ns).dec();
     const reason =
-      (client as any).disconnectReason ??          
-      (client as any).conn?.closeReason ??         
-      'unknown';
+      (client as any).disconnectReason ?? (client as any).conn?.closeReason ?? 'unknown';
     this.prom.wsDisconnectsTotal.labels(ns, reason).inc();
 
-    const roomName = client.data.roomName;
-    if (!roomName) return;
+    const roomName: string | undefined = client.data.roomName;
+    const payload: ToolBackendPayload | undefined = client.data.payload;
+    if (!roomName || !payload?.room_id) return;
 
-    // TODO: 방에 아무도 없을 때 삭제
+    const existingTimer = this.roomEvictionTimers.get(roomName);
+    if (existingTimer) {
+      clearTimeout(existingTimer);
+    }
+
+    const timer = setTimeout(async () => {
+      const sockets = await this.server.in(roomName).allSockets();
+      if (sockets.size > 0) return;
+
+      await this.codeeditorService.flushRoomUpdates(payload.room_id);
+      await this.codeeditorService.maybeSnapShot(payload.room_id, true);
+
+      this.codeeditorService.clearRoomState(payload.room_id);
+      this.codeeditorRepo.delete(payload.room_id);
+      this.roomEvictionTimers.delete(roomName);
+
+      this.logger.log(`codeeditor room evicted: ${payload.room_id}`);
+    }, ROOM_EVICT_DELAY_MS);
+    this.roomEvictionTimers.set(roomName, timer);
   }
 
   @SubscribeMessage(CODEEDITOR_EVENT_NAME.HEALTH_CHECK)
-  healthCheck(
-    //
-    @ConnectedSocket() client: Socket,
-  ) {
+  healthCheck(@ConnectedSocket() client: Socket) {
     try {
       const payload: ToolBackendPayload = client.data.payload;
       this.logger.log('health체크중: ', payload);
@@ -142,27 +164,32 @@ export class CodeeditorWebsocketGateway implements OnGatewayInit, OnGatewayConne
 
   // 좀더 안전하게 하기 위한 ready
   @SubscribeMessage('yjs-ready')
-  async onReady(@ConnectedSocket() client: Socket) {
+  async onReady(@ConnectedSocket() client: Socket, @MessageBody() payload?: YjsSyncReqPayload) {
     if (client.data.__yjsReadySent) return;
     client.data.__yjsReadySent = true;
 
-    const payload: ToolBackendPayload = client.data.payload;
-    const full = await this.codeeditorService.ensureDocFromRedis(payload.room_id);
+    const dataPayload: ToolBackendPayload = client.data.payload;
+    await this.codeeditorService.ensureDocFromRedis(dataPayload.room_id);
+
+    const entry = this.codeeditorRepo.ensure(dataPayload.room_id);
+    const clientStateVector =
+      this.codeeditorService.normalizeToUint8Array(payload?.state_vector) ?? new Uint8Array();
+    const diff = Y.encodeStateAsUpdate(entry.doc, clientStateVector);
+    const serverStateVector = Y.encodeStateVector(entry.doc);
+    this.logger.debug(
+      `yjs-ready room=${dataPayload.room_id} client_sv=${clientStateVector.byteLength} diff=${diff.byteLength}`,
+    );
 
     client.emit('yjs-init', {
-      update: Buffer.from(full.update),
-      seq: full.seq,
+      update: Buffer.from(diff),
+      state_vector: Buffer.from(serverStateVector),
       origin: 'INIT',
     });
   }
 
   // 업데이트 하고 싶다고 보내는 메시지
   @SubscribeMessage('yjs-update')
-  @UsePipes(
-    new ValidationPipe({
-      whitelist: true,
-    }),
-  )
+  @UsePipes(new ValidationPipe({ whitelist: true }))
   async handleYjsUpdate(
     @ConnectedSocket() client: Socket,
     @MessageBody() payload: YjsUpdateClientPayload,
@@ -170,6 +197,7 @@ export class CodeeditorWebsocketGateway implements OnGatewayInit, OnGatewayConne
     // 캐싱된 룸 이름 사용
     const roomName = client.data.roomName;
     const dataPayload: ToolBackendPayload = client.data.payload;
+    if (!roomName) return;
 
     try {
       const bufs = this.codeeditorService.normalizeToBuffers(payload);
@@ -182,78 +210,27 @@ export class CodeeditorWebsocketGateway implements OnGatewayInit, OnGatewayConne
         return;
       }
 
-      // 클라이언트에 마지막 값과 비교
-      const missed = this.codeeditorRepo.getUpdatesSince(dataPayload.room_id, payload.last_seq);
-
-      if (missed === null) {
-        // 뒤처지면 전체를 sync해서 보낸다. 그리고 업데이트를 하고 보내면 좋겠다. 그러니까 전체 추가 후 업데이트
-        const full = this.codeeditorRepo.encodeFull(dataPayload.room_id);
-        const msg: YjsSyncServerPayload = {
-          type: 'full',
-          ok: true,
-          server_seq: full.seq,
-          update: Buffer.from(full.update),
-          origin: 'UPDATE_REJECTED',
-        };
-        client.emit('yjs-sync', msg); // 새롭게 전체 업데이트 한것 까지 추가해서 보내면 좋다.
-        return;
-      }
-
-      if (missed.length > 0) {
-        // 이것도 그냥 업데이트 하고 patch로 보내면 좋을것 같다.
-        const msg: YjsSyncServerPayload = {
-          type: 'patch',
-          ok: true,
-          from_seq: missed[0].seq,
-          to_seq: missed[missed.length - 1].seq,
-          updates: missed.map((u) => Buffer.from(u.update)),
-          server_seq: this.codeeditorRepo.ensure(dataPayload.room_id).seq,
-          origin: 'UPDATE_REJECTED',
-        };
-        client.emit('yjs-sync', msg);
-        return;
-      }
-
-      let firstSeq: number | null = null;
-      let lastSeq = payload.last_seq;
-
-      const appliedUpdates: Buffer[] = [];
+      const appliedUpdates: Uint8Array[] = [];
       for (const b of bufs) {
-        const seq = this.codeeditorRepo.applyAndAppendUpdate(
-          dataPayload.room_id,
-          new Uint8Array(b),
-        );
-        if (firstSeq === null) firstSeq = seq;
-        lastSeq = seq;
-        appliedUpdates.push(b);
+        const u = new Uint8Array(b);
+        this.codeeditorRepo.applyAndAppendUpdate(dataPayload.room_id, u);
+        appliedUpdates.push(u);
       }
 
-      // ack에 경우는 마지막만
-      client.emit('yjs-sync', {
-        type: 'ack',
-        ok: true,
-        server_seq: lastSeq,
-      } satisfies YjsSyncServerPayload);
-
-      // 브로드캐스트: 단일/배치 둘 다 가능
-      if (appliedUpdates.length === 1) {
-        client.to(roomName).emit('yjs-update', { seq: lastSeq, update: appliedUpdates[0] });
-      } else {
-        client.to(roomName).emit('yjs-update', {
-          from_seq: firstSeq!,
-          to_seq: lastSeq,
-          updates: appliedUpdates,
-        });
-      }
-
-      // 모든 업데이트가 끝났을때 redis에 업데이트 한다.
-      await this.codeeditorService.appendUpdatesToStream(
-        dataPayload.room_id,
-        appliedUpdates.map((b) => new Uint8Array(b)),
-        dataPayload.user_id,
+      const merged =
+        appliedUpdates.length === 1
+          ? Buffer.from(appliedUpdates[0])
+          : Buffer.from(Y.mergeUpdates(appliedUpdates));
+      this.logger.debug(
+        `yjs-update room=${dataPayload.room_id} updates=${appliedUpdates.length} merged=${merged.byteLength}`,
       );
 
-      await this.codeeditorService.maybeSnapShot(dataPayload.room_id);
+      client.to(roomName).emit('yjs-update', { update: merged, ts: payload.ts });
+      this.codeeditorService.queueUpdatesToStream(
+        dataPayload.room_id,
+        appliedUpdates,
+        dataPayload.user_id,
+      );
     } catch (error) {
       this.logger.error(`Yjs Update Error: ${error?.message ?? error}`);
       const msg: YjsSyncServerPayload = {
@@ -275,40 +252,20 @@ export class CodeeditorWebsocketGateway implements OnGatewayInit, OnGatewayConne
     if (!roomName) return;
 
     try {
-      const missed = this.codeeditorRepo.getUpdatesSince(dataPayload.room_id, payload.last_seq);
+      const entry = this.codeeditorRepo.ensure(dataPayload.room_id);
+      const clientStateVector =
+        this.codeeditorService.normalizeToUint8Array(payload?.state_vector) ?? new Uint8Array();
+      const diff = Y.encodeStateAsUpdate(entry.doc, clientStateVector);
+      const serverStateVector = Y.encodeStateVector(entry.doc);
+      this.logger.debug(
+        `yjs-sync-req room=${dataPayload.room_id} reason=${payload?.reason ?? 'unknown'} client_sv=${clientStateVector.byteLength} diff=${diff.byteLength}`,
+      );
 
-      if (missed === null) {
-        const full = this.codeeditorRepo.encodeFull(dataPayload.room_id);
-        const msg: YjsSyncServerPayload = {
-          type: 'full',
-          ok: true,
-          server_seq: full.seq,
-          update: Buffer.from(full.update),
-          origin: 'SYNC_REQ',
-        };
-        client.emit('yjs-sync', msg);
-        return;
-      }
-
-      if (missed.length > 0) {
-        const msg: YjsSyncServerPayload = {
-          type: 'patch',
-          ok: true,
-          from_seq: missed[0].seq,
-          to_seq: missed[missed.length - 1].seq,
-          updates: missed.map((u) => Buffer.from(u.update)),
-          server_seq: this.codeeditorRepo.ensure(dataPayload.room_id).seq,
-          origin: 'SYNC_REQ',
-        };
-        client.emit('yjs-sync', msg);
-        return;
-      }
-
-      // 이미 최신이면 ack로 알려주기
       client.emit('yjs-sync', {
-        type: 'ack',
+        type: 'diff',
         ok: true,
-        server_seq: this.codeeditorRepo.ensure(dataPayload.room_id).seq,
+        update: Buffer.from(diff),
+        server_state_vector: Buffer.from(serverStateVector),
         origin: 'SYNC_REQ',
       } satisfies YjsSyncServerPayload);
     } catch (error: any) {
@@ -334,21 +291,4 @@ export class CodeeditorWebsocketGateway implements OnGatewayInit, OnGatewayConne
       this.logger.error(`Awareness Update Error: ${error.message}`);
     }
   }
-
-  // 이 부분은 잠시 비활성화 할 예정입니다.
-  // @SubscribeMessage('request-sync')
-  // handleRequestSync(@ConnectedSocket() client: Socket) {
-  //   const roomName = client.data.roomName;
-  //   let doc = this.codeeditorRepo.get(roomName);
-
-  //   if (!doc) {
-  //     doc = new Y.Doc();
-  //     this.codeeditorRepo.set(roomName, doc);
-  //   };
-
-  //   const fullUpdate = Y.encodeStateAsUpdate(doc);
-  //   client.emit('yjs-update', fullUpdate);
-
-  //   this.logger.log('doc length', doc?.getText('monaco').length);
-  // }
 }

--- a/rep/tool_backend/src/codeeditor/codeeditor.service.ts
+++ b/rep/tool_backend/src/codeeditor/codeeditor.service.ts
@@ -7,24 +7,76 @@ import {
   CACHE_CODEEDITOR_SNAPSHOT_KEY_NAME,
   CACHE_CODEEDITOR_STREAM_KEY_NAME,
   CACHE_NAMESPACE_NAME,
+  CODEEDITOR_BATCH_MAX_UPDATES,
+  CODEEDITOR_BATCH_WINDOW_MS,
+  CODEEDITOR_SNAPSHOT_EVERY_MS,
   decodeB64,
   encodeB64,
   REDIS_SERVER,
-  SNAPSHOT_N,
   STREAM_MAXLEN,
 } from '@/infra/cache/cache.constants';
 import type { RedisClientType } from 'redis';
 import { CodeeditorRepository, UpdateEntry, YjsUpdateClientPayload } from '@/infra/memory/tool';
+import * as Y from 'yjs';
 
 @Injectable()
 export class CodeeditorService {
   private logger = new Logger(CodeeditorService.name);
+  private pendingStreamWrites = new Map<
+    string,
+    {
+      updates: Uint8Array[];
+      user_id: string;
+      timer?: NodeJS.Timeout;
+      flushing: boolean;
+    }
+  >();
+  private lastSnapshotAt = new Map<string, number>();
+  private perSec = {
+    queuedUpdates: 0,
+    flushes: 0,
+    redisWrites: 0,
+    mergedUpdatesToRedis: 0,
+  };
+  private readonly perSecTimer: NodeJS.Timeout;
+  private readonly memoryProbeTimer?: NodeJS.Timeout;
 
   constructor(
     private readonly guard: GuardService,
     @Inject(REDIS_SERVER) private readonly redis: RedisClientType<any, any>, // redis를 사용하기 위한 부분
     private readonly codeeditorRepo: CodeeditorRepository,
-  ) {}
+  ) {
+    this.perSecTimer = setInterval(() => {
+      const { queuedUpdates, flushes, redisWrites, mergedUpdatesToRedis } = this.perSec;
+      if (queuedUpdates > 0 || flushes > 0 || redisWrites > 0 || mergedUpdatesToRedis > 0) {
+        this.logger.log(
+          `[codeeditor-throughput/1s] queued_updates=${queuedUpdates} flushes=${flushes} redis_writes=${redisWrites} merged_updates_to_redis=${mergedUpdatesToRedis}`,
+        );
+      }
+      this.perSec.queuedUpdates = 0;
+      this.perSec.flushes = 0;
+      this.perSec.redisWrites = 0;
+      this.perSec.mergedUpdatesToRedis = 0;
+    }, 1000);
+    this.perSecTimer.unref();
+
+    if (process.env.CODEEDITOR_MEMORY_PROBE === 'true') {
+      this.memoryProbeTimer = setInterval(() => {
+        const mu = process.memoryUsage();
+        this.logger.log(
+          `[codeeditor-memory/10s] rooms=${this.codeeditorRepo.getRoomCount()} rss_mb=${(mu.rss / 1048576).toFixed(1)} heap_used_mb=${(mu.heapUsed / 1048576).toFixed(1)} heap_total_mb=${(mu.heapTotal / 1048576).toFixed(1)} external_mb=${(mu.external / 1048576).toFixed(1)}`,
+        );
+
+        const samples = this.codeeditorRepo.getAllRoomStats(5);
+        for (const s of samples) {
+          this.logger.log(
+            `[codeeditor-room/10s] room=${s.room_id} seq=${s.seq} struct_buckets=${s.client_struct_buckets} total_structs=${s.total_structs} encode_full_bytes=${s.encode_full_bytes}`,
+          );
+        }
+      }, 10_000);
+      this.memoryProbeTimer.unref();
+    }
+  }
 
   async guardService(token: string, type: 'main' | 'sub'): Promise<ToolBackendPayload> {
     const verified = await this.guard.verify(token);
@@ -57,6 +109,12 @@ export class CodeeditorService {
     if (value instanceof ArrayBuffer) return Buffer.from(new Uint8Array(value));
     return null;
   }
+
+  normalizeToUint8Array(value: unknown): Uint8Array | null {
+    const buf = this.normalizeToBuffer(value);
+    return buf ? new Uint8Array(buf) : null;
+  }
+
   normalizeToBuffers(payload: YjsUpdateClientPayload): Buffer[] | null {
     // 검증을 위한 buf
     const toBuf = (v: any): Buffer | null => {
@@ -140,31 +198,91 @@ export class CodeeditorService {
 
   // stream update
   async appendUpdatesToStream(room_id: string, updates: Uint8Array[], user_id: string) {
-    const streamKey: string = this.streamKey(room_id);
-    let lastId: string = '0-0';
+    if (!updates.length) return '0-0';
 
-    for (const u of updates) {
-      lastId = await this.redis.xAdd(streamKey, '*', {
-        [CACHE_CODEEDITOR_STREAM_KEY_NAME.UPDATE]: encodeB64(u),
-        [CACHE_CODEEDITOR_STREAM_KEY_NAME.TX]: String(Date.now()),
-        [CACHE_CODEEDITOR_STREAM_KEY_NAME.USER_ID]: user_id,
-      });
-    }
+    const streamKey: string = this.streamKey(room_id);
+    const merged = updates.length === 1 ? updates[0] : Y.mergeUpdates(updates);
+    const lastId = await this.redis.xAdd(streamKey, '*', {
+      [CACHE_CODEEDITOR_STREAM_KEY_NAME.UPDATE]: encodeB64(merged),
+      [CACHE_CODEEDITOR_STREAM_KEY_NAME.TX]: String(Date.now()),
+      [CACHE_CODEEDITOR_STREAM_KEY_NAME.USER_ID]: user_id,
+    });
+    this.perSec.redisWrites += 1;
+    this.perSec.mergedUpdatesToRedis += updates.length;
 
     return lastId;
   }
 
-  // stream 300 마다 snapshot 작성
-  async maybeSnapShot(room_id: string) {
-    const state = this.codeeditorRepo.ensure(room_id);
-    if (state.seq % SNAPSHOT_N !== 0) return; // 현재 stream이 정한 갯수 만큼 찍혔다면 업데이트한다.
+  queueUpdatesToStream(room_id: string, updates: Uint8Array[], user_id: string) {
+    if (!updates.length) return;
+    this.perSec.queuedUpdates += updates.length;
+    const pending = this.pendingStreamWrites.get(room_id) ?? {
+      updates: [],
+      user_id,
+      flushing: false,
+    };
+    pending.updates.push(...updates);
+    pending.user_id = user_id;
+    this.pendingStreamWrites.set(room_id, pending);
+    this.logger.debug(
+      `queue-stream room=${room_id} incoming=${updates.length} queued=${pending.updates.length}`,
+    );
 
-    // 추후 여러 pod 대비 lock을 추가해야 한다. ( 지금은 스킵 )
+    if (pending.updates.length >= CODEEDITOR_BATCH_MAX_UPDATES) {
+      void this.flushRoomUpdates(room_id);
+      return;
+    }
+
+    if (!pending.timer) {
+      pending.timer = setTimeout(() => {
+        void this.flushRoomUpdates(room_id);
+      }, CODEEDITOR_BATCH_WINDOW_MS);
+    }
+  }
+
+  async flushRoomUpdates(room_id: string) {
+    const pending = this.pendingStreamWrites.get(room_id);
+    if (!pending || pending.flushing || pending.updates.length === 0) return;
+    this.perSec.flushes += 1;
+
+    pending.flushing = true;
+    if (pending.timer) {
+      clearTimeout(pending.timer);
+      pending.timer = undefined;
+    }
 
     try {
-      const snapU8 = this.codeeditorRepo.encodeSnapshot(room_id); // snapshot을 만든다. ( 성능 병목 현상이 뜨는 장소 )
+      const updates = pending.updates;
+      pending.updates = [];
+
+      this.logger.debug(`flush-stream room=${room_id} updates=${updates.length}`);
+      await this.appendUpdatesToStream(room_id, updates, pending.user_id);
+      await this.maybeSnapShot(room_id);
+    } catch (err) {
+      this.logger.error(`flushRoomUpdates error room=${room_id}`, err as any);
+      pending.flushing = false;
+      return;
+    }
+
+    pending.flushing = false;
+
+    if (pending.updates.length > 0) {
+      void this.flushRoomUpdates(room_id);
+      return;
+    }
+
+    this.pendingStreamWrites.delete(room_id);
+  }
+
+  // time-window 기반 snapshot 생성
+  async maybeSnapShot(room_id: string, force = false) {
+    const now = Date.now();
+    const lastAt = this.lastSnapshotAt.get(room_id) ?? 0;
+    if (!force && now - lastAt < CODEEDITOR_SNAPSHOT_EVERY_MS) return;
+
+    try {
+      const snapU8 = this.codeeditorRepo.encodeSnapshot(room_id);
       const snapB64 = encodeB64(snapU8);
-      const ts = String(Date.now());
 
       const streamKey = this.streamKey(room_id);
       const latest = await this.redis.xRevRange(streamKey, '+', '-', { COUNT: 1 });
@@ -176,15 +294,26 @@ export class CodeeditorService {
       tx.hSet(snapKey, {
         [CACHE_CODEEDITOR_SNAPSHOT_KEY_NAME.SNAP]: snapB64,
         [CACHE_CODEEDITOR_SNAPSHOT_KEY_NAME.IDX]: idx,
-        [CACHE_CODEEDITOR_SNAPSHOT_KEY_NAME.TX]: ts,
+        [CACHE_CODEEDITOR_SNAPSHOT_KEY_NAME.TX]: String(now),
       });
 
-      tx.xTrim(streamKey, 'MAXLEN', STREAM_MAXLEN, { strategyModifier: '~' }); // 원자성 보장
+      tx.xTrim(streamKey, 'MAXLEN', STREAM_MAXLEN, { strategyModifier: '~' });
 
       const res = await tx.exec();
       if (!res) return;
+
+      this.lastSnapshotAt.set(room_id, now);
     } catch (err) {
       this.logger.error(err);
     }
+  }
+
+  clearRoomState(room_id: string) {
+    const pending = this.pendingStreamWrites.get(room_id);
+    if (pending?.timer) {
+      clearTimeout(pending.timer);
+    }
+    this.pendingStreamWrites.delete(room_id);
+    this.lastSnapshotAt.delete(room_id);
   }
 }

--- a/rep/tool_backend/src/infra/cache/cache.constants.ts
+++ b/rep/tool_backend/src/infra/cache/cache.constants.ts
@@ -18,6 +18,9 @@ export class OutbouncCache<T> {
 export const SNAPSHOT_N = 300; // snapshot을 찍는 stream 갯수들
 export const STREAM_MAXLEN = 5000; // stream이 유지할수 있는 최대 길이
 export const SNAPSHOT_LOCK_TTL_MS = 10_000; // 살아있는 시간이다 스냅샷을 찍는 락을 잡는다. 여러 pod에서 작업시 필요하다.
+export const CODEEDITOR_BATCH_WINDOW_MS = 1000; // 1초 동안 codeeditor update를 모아서 Redis에 반영
+export const CODEEDITOR_BATCH_MAX_UPDATES = 300; // 너무 오래 대기하지 않도록 즉시 flush 캡
+export const CODEEDITOR_SNAPSHOT_EVERY_MS = 60_000; // codeeditor snapshot 최소 주기 (1분)
 
 // whiteboard와 관련된 변수들
 export const WHITEBOARD_STREAM_MAXLEN = 50_000; // 50000의 stream을 최댓값으로 가진다.

--- a/rep/tool_backend/src/infra/memory/tool/codeeditor-repo.ts
+++ b/rep/tool_backend/src/infra/memory/tool/codeeditor-repo.ts
@@ -7,6 +7,67 @@ import * as Y from 'yjs';
 export class CodeeditorRepository implements YjsRepository {
   private readonly roomDocs = new Map<string, YjsRoomEntry>();
 
+  getRoomCount(): number {
+    return this.roomDocs.size;
+  }
+
+  getRoomStats(room_id: string): {
+    room_id: string;
+    seq: number;
+    client_struct_buckets: number;
+    total_structs: number;
+    encode_full_bytes: number;
+  } | null {
+    const entry = this.roomDocs.get(room_id);
+    if (!entry) return null;
+
+    const store = (entry.doc as any).store;
+    const clients: Map<number, Array<unknown>> | undefined = store?.clients;
+
+    let totalStructs = 0;
+    let clientStructBuckets = 0;
+    if (clients && typeof clients.forEach === 'function') {
+      clientStructBuckets = clients.size;
+      clients.forEach((arr) => {
+        totalStructs += Array.isArray(arr) ? arr.length : 0;
+      });
+    }
+
+    const encodeFullBytes = Y.encodeStateAsUpdate(entry.doc).byteLength;
+
+    return {
+      room_id,
+      seq: entry.seq,
+      client_struct_buckets: clientStructBuckets,
+      total_structs: totalStructs,
+      encode_full_bytes: encodeFullBytes,
+    };
+  }
+
+  getAllRoomStats(limit = 5): Array<{
+    room_id: string;
+    seq: number;
+    client_struct_buckets: number;
+    total_structs: number;
+    encode_full_bytes: number;
+  }> {
+    const stats: Array<{
+      room_id: string;
+      seq: number;
+      client_struct_buckets: number;
+      total_structs: number;
+      encode_full_bytes: number;
+    }> = [];
+
+    for (const room_id of this.roomDocs.keys()) {
+      const stat = this.getRoomStats(room_id);
+      if (stat) stats.push(stat);
+      if (stats.length >= limit) break;
+    }
+
+    return stats;
+  }
+
   // yjs room 정보 가져오기
   get(room_id: string): YjsRoomEntry | undefined {
     return this.roomDocs.get(room_id);

--- a/rep/tool_backend/src/infra/memory/tool/yjs-repo.ts
+++ b/rep/tool_backend/src/infra/memory/tool/yjs-repo.ts
@@ -1,4 +1,4 @@
-import { IsDefined, IsInt, IsNotEmpty, IsOptional, IsString, Min } from 'class-validator';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
 import * as Y from 'yjs';
 
 export const YJS_ENTITY_MAX_NUMBER = 1000; // 최대 사이즈
@@ -46,36 +46,30 @@ export interface YjsRepository {
 }
 
 export class YjsUpdateClientPayload {
-  @IsInt()
-  @Min(0)
-  last_seq: number; // 클라가 마지막으로 적용한 서버 seq
-
   @IsOptional()
   update?: unknown; // yjs update (socket.io 전송용) 지금은 unknown으로하고 서버에서 검증
 
   @IsOptional()
   updates?: unknown; // 한번에 보낼때 이를 참고
+
+  @IsOptional()
+  ts?: unknown;
 }
 
 export type YjsSyncOrigin =
-  | 'UPDATE_REJECTED' // yjs-update 처리 중 missed라서 drop + sync 내려준다
   | 'SYNC_REQ' // yjs-sync-req 요청에 대한 응답
   | 'INIT' // 최초 접속/재접속 등
   | 'ADMIN';
 
 // sync와 관련된 payload
 export type YjsSyncServerPayload =
-  | { type: 'ack'; ok: true; server_seq: number; origin?: YjsSyncOrigin }
   | {
-      type: 'patch';
+      type: 'diff';
       ok: true;
-      from_seq: number;
-      to_seq: number;
-      updates: Buffer[];
-      server_seq: number;
+      update: Buffer;
+      server_state_vector?: Buffer;
       origin: YjsSyncOrigin;
     }
-  | { type: 'full'; ok: true; server_seq: number; update: Buffer; origin: YjsSyncOrigin }
   | {
       type: 'error';
       ok: false;
@@ -85,9 +79,13 @@ export type YjsSyncServerPayload =
     }; // error 코드들 BAD_PAYLOAD는 update의 종류에 따라서
 
 export class YjsSyncReqPayload {
-  @IsInt()
-  @Min(0)
-  last_seq: number;
+  @IsOptional()
+  state_vector?: unknown;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  reason?: string;
 }
 
 // 아래는 화이트 보드용


### PR DESCRIPTION


## ✅ 작업 내용
### BE
- Yjs 동기화 모델을 seq/ack 기반에서 state vector diff 기반으로 전환
- 룸 eviction 지연 처리 및 정리 로직 추가(재접속 안정화, 메모리 누수 방지)
- Redis 스트림 write 경로 개선 및 동기화 처리 흐름 정리
- 메모리 저장소/스냅샷/업데이트 로그 관리 개선
- 캐시 상수 및 관련 설정 업데이트

### FE
- CodeEditor 동기화 로직을 seq/ack 기반에서 state vector diff 기반으로 변경
- 동기화 타입/에러 타입 분리 및 logging 유틸 추가
- API 클라이언트 및 로깅/모니터링 관련 흐름 정리
- 기타 가상 테스트 시나리오 추가 및 설정 변경


---

## 🤔 리뷰 요구사항

기존 코드 에디터의 Yjs 동기화 구조를 재검토한 결과, 클라이언트와 서버 간 업데이트 동기화 과정에서 seq 기반 처리 로직이 상당히 복잡해지고 일부 상황에서 전체 상태 동기화(full-state sync)가 반복적으로 발생할 수 있는 구조라는 판단을 내렸습니다. 이로 인해 문서 크기가 증가할수록 네트워크 payload가 커지고, 또 클라이언트에서 update가 발생할 때마다 redis에 빈번하게 바로 write되는 문제가 있었습니다.

이를 개선하기 위해 기존 seq 기반 동기화 모델을 -> state-vector diff 기반 동기화 구조로 수정하였습니다. 기존 Yjs 라이브러리에서 제공하는 state vector를 활용하여 client-server 간 문서 상태 diff만 계산하고 필요한 업데이트만 전송되도록 구조를 단순화했습니다.

최종적으로 아래 사항을 로그에서 확인하였습니다.
- yjs-ready에서 client_sv 기준 diff 계산이 정상 수행됨
- yjs-update는 작은 incremental update로 처리되고 있음
- Redis write는 batching(flush)으로 정상 동작
- yjs-sync-req에서 state vector 기반 diff 복구가 정상 동작

아직 end-to-end 테스트까진 진행하지 못해서 버그가 있다면 자유롭게 의견주시면 좋을 것 같습니다.

---

## 📸 테스트 결과 및 스크린샷

동시 입력 부하 및 문서 수렴 상태를 확인하기 위해 각 이벤트마다의 로그를 분석 후 확인해보았습니다.
### 테스트 흐름
- 20명 동시 접속
- 랜덤 타이핑
- 1명 네트워크 단절 후 reconnect
- 문서 상태 수렴 확인

### `yjs-ready` 연속 발생
```bash
yjs-ready room=... client_sv=1 diff=2
```
- 다수의 클라이언트(약 20명)가 연결 직후 yjs-ready를 전송
- 서버가 각 client_sv를 기준으로 diff를 계산하여 초기 sync를 수행하는 것을 확인
- 참고로 초기 연결 시 diff=2인 이유는, 클라이언트가 처음 접속했기 때문에 서버 문서의 초기 CRDT 구조 2개 struct(update)가 아직 없어서 이를 전송해야 하는 상태이기 때문

### yjs-update 지속 수신 + 병합
```
yjs-update room=... updates=1 merged=18
yjs-update room=... updates=1 merged=20
```
- 서버가 클라이언트 update를 수신하고, merged payload 크기를 로깅
- merged byte 크기가 작은 값(18~20)으로 유지 → 작은 incremental update 기반

### Redis 스트림 큐잉 + 배치 flush
```
queue-stream room=... incoming=1 queued=15
flush-stream room=... updates=15
[codeeditor-throughput/1s] queued_updates=15 flushes=1 redis_writes=1 merged_updates_to_redis=15
```
- update는 바로 redis에 쓰지 않고 큐에 쌓아 일정 주기마다 flush-stream으로 배칭해서 write를 수행
- 1초 단위 throughput 로그에서 queued_updates 대비 redis_writes가 1로 유지되는 것을 확인

### yjs-sync-req 발생 확인
```
yjs-ready room=... client_sv=103 diff=1112
yjs-sync-req room=... reason=MANUAL client_sv=103 diff=1112
```
- 클라이언트가 state_vector를 보내고, 서버가 diff를 계산하는 정상 복구 흐름을 확인
- diff=1112는 누락분 존재를 뜻하기 때문에 -> 서버가 현재 1215 update 상태이므로 -> 서버가 정상적으로 diff를 제공함

### 20명 가상 사용자 문서 수렴 테스트
<img width="532" height="198" alt="image" src="https://github.com/user-attachments/assets/75f90cb7-53ca-4df4-8b13-d88218206c77" />